### PR TITLE
Add manual configuration reload capability

### DIFF
--- a/include/config.ternary.fission.server.h
+++ b/include/config.ternary.fission.server.h
@@ -183,6 +183,12 @@ public:
     bool loadConfiguration();
     
     /**
+     * We reload configuration unconditionally from the current file
+     * This allows manual refresh of configuration without checking modification time
+     */
+    bool reloadConfiguration();
+
+    /**
      * We reload configuration if file has been modified
      * This enables runtime configuration updates without daemon restart
      */

--- a/src/cpp/config.ternary.fission.server.cpp
+++ b/src/cpp/config.ternary.fission.server.cpp
@@ -106,6 +106,14 @@ bool ConfigurationManager::loadConfiguration() {
 }
 
 /**
+ * We reload configuration unconditionally from the current file
+ * This allows manual refresh of configuration without checking modification time
+ */
+bool ConfigurationManager::reloadConfiguration() {
+    return loadConfiguration();
+}
+
+/**
  * We reload configuration if file has been modified
  * This enables runtime configuration updates without daemon restart
  */


### PR DESCRIPTION
## Summary
- add `reloadConfiguration` API to ConfigurationManager to force re-reading the config file

## Testing
- `make` *(fails: 'SSLServer' is not a member of `httplib`)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6895681a69f8832ba8c67de9f0970aed