### PR TITLE
Mark readPIDFromFile as const

### DIFF
--- a/include/daemon.ternary.fission.server.h
+++ b/include/daemon.ternary.fission.server.h
@@ -155,7 +155,7 @@ private:
     bool createPIDFile();                       // Create and lock PID file
     bool removePIDFile();                       // Remove PID file on shutdown
     bool validatePIDFile();                     // Validate existing PID file
-    pid_t readPIDFromFile();                    // Read PID from existing file
+    pid_t readPIDFromFile() const;              // Read PID from existing file
     bool lockPIDFile(int fd);                   // Lock PID file exclusively
     
     // We implement signal handling methods


### PR DESCRIPTION
## Summary
- ensure DaemonTernaryFissionServer's PID-file reader is declared `const` to match its definition

## Testing
- `make all` *(fails: httplib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68956c3a7c54832bb0e60b297e0fcd99