### PR TITLE
Add statusToString utility and use in logStatusChange

### DIFF
--- a/include/daemon.ternary.fission.server.h
+++ b/include/daemon.ternary.fission.server.h
@@ -183,6 +183,7 @@ private:
     // We implement status reporting methods
     void updateDaemonStatus(DaemonStatus new_status); // Update daemon status atomically
     std::string getStatusString() const;        // Get human-readable status string
+    static std::string statusToString(DaemonStatus status); // Convert status enum to string
     void logStatusChange(DaemonStatus old_status, DaemonStatus new_status); // Log status changes
     
     // We implement configuration validation methods

--- a/src/cpp/daemon.ternary.fission.server.cpp
+++ b/src/cpp/daemon.ternary.fission.server.cpp
@@ -917,16 +917,11 @@ void DaemonTernaryFissionServer::updateDaemonStatus(DaemonStatus new_status) {
  * We log daemon status changes
  * This method records status transitions for operational monitoring
  */
-void DaemonTernaryFissionServer::logStatusChange(DaemonStatus old_status, DaemonStatus new_status) {
-    std::cout << "Daemon status changed from " << getStatusString() << " to " << getStatusString() << std::endl;
-}
-
 /**
- * We get human-readable status string
- * This method converts status enum to readable string
+ * Convert status enum to readable string
  */
-std::string DaemonTernaryFissionServer::getStatusString() const {
-    switch (getStatus()) {
+std::string DaemonTernaryFissionServer::statusToString(DaemonStatus status) {
+    switch (status) {
         case DaemonStatus::STOPPED: return "STOPPED";
         case DaemonStatus::STARTING: return "STARTING";
         case DaemonStatus::RUNNING: return "RUNNING";
@@ -935,6 +930,19 @@ std::string DaemonTernaryFissionServer::getStatusString() const {
         case DaemonStatus::RESTARTING: return "RESTARTING";
         default: return "UNKNOWN";
     }
+}
+
+void DaemonTernaryFissionServer::logStatusChange(DaemonStatus old_status, DaemonStatus new_status) {
+    std::cout << "Daemon status changed from " << statusToString(old_status)
+              << " to " << statusToString(new_status) << std::endl;
+}
+
+/**
+ * We get human-readable status string
+ * This method converts current status enum to readable string
+ */
+std::string DaemonTernaryFissionServer::getStatusString() const {
+    return statusToString(getStatus());
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add static `statusToString` helper for converting `DaemonStatus` values to readable strings.
- Rewrite `logStatusChange` to use `statusToString` for old and new statuses.
- Simplify `getStatusString` by delegating to the new helper.

## Testing
- `make` *(fails: passing ‘const DaemonTernaryFissionServer’ as ‘this’ argument discards qualifiers)*


------
https://chatgpt.com/codex/tasks/task_e_68956e2feb18832b8c1387745cd27348