### PR TITLE
Add debug mode flag and diagnostics to daemon server

### DIFF
--- a/include/daemon.ternary.fission.server.h
+++ b/include/daemon.ternary.fission.server.h
@@ -122,6 +122,7 @@ private:
     std::atomic<DaemonStatus> daemon_status_;   // Current daemon operational status
     std::atomic<bool> shutdown_requested_;      // Graceful shutdown request flag
     std::atomic<bool> restart_requested_;       // Daemon restart request flag
+    std::atomic<bool> debug_mode_;              // Verbose diagnostics flag
     std::chrono::system_clock::time_point start_time_; // Daemon startup timestamp
     
     // We manage signal handling system

--- a/src/cpp/daemon.ternary.fission.server.cpp
+++ b/src/cpp/daemon.ternary.fission.server.cpp
@@ -124,6 +124,7 @@ DaemonTernaryFissionServer::DaemonTernaryFissionServer(std::unique_ptr<Configura
     , daemon_status_(DaemonStatus::STOPPED)
     , shutdown_requested_(false)
     , restart_requested_(false)
+    , debug_mode_(false)
     , start_time_(std::chrono::system_clock::now())
     , log_rotation_enabled_(true)
     , log_rotation_active_(false)
@@ -206,6 +207,16 @@ bool DaemonTernaryFissionServer::initialize() {
     access_log_path_ = logging_config.access_log_path;
     error_log_path_ = logging_config.error_log_path;
     debug_log_path_ = logging_config.debug_log_path;
+
+    if (debug_mode_) {
+        std::ofstream dbg(debug_log_path_, std::ios::app);
+        if (dbg.is_open()) {
+            dbg << "config: pid_file=" << process_info_->pid_file_path
+                << " work_dir=" << process_info_->working_directory
+                << " log_level=" << logging_config.log_level
+                << std::endl;
+        }
+    }
     
     // We check if another instance is already running
     if (isAnotherInstanceRunning()) {
@@ -830,6 +841,18 @@ bool DaemonTernaryFissionServer::createLogDirectory(const std::string& log_path)
 void DaemonTernaryFissionServer::resourceMonitorWorker() {
     while (resource_monitoring_) {
         collectSystemMetrics();
+
+        if (debug_mode_) {
+            auto usage = getResourceUsage();
+            std::ofstream dbg(debug_log_path_, std::ios::app);
+            if (dbg.is_open()) {
+                dbg << "cpu_percent=" << usage["cpu_percent"]
+                    << " memory_bytes=" << usage["memory_bytes"]
+                    << " file_descriptors=" << usage["file_descriptors"]
+                    << std::endl;
+            }
+        }
+
         std::this_thread::sleep_for(monitoring_interval_);
     }
 }
@@ -1091,7 +1114,17 @@ bool DaemonTernaryFissionServer::waitForShutdown(std::chrono::seconds timeout) c
 }
 
 void DaemonTernaryFissionServer::setDebugMode(bool enable_debug) {
-    // Debug mode implementation would adjust logging verbosity
+    debug_mode_.store(enable_debug, std::memory_order_relaxed);
+
+    // Adjust logging configuration through environment variable
+    const char* level = enable_debug ? "debug" : "info";
+    ::setenv("TERNARY_LOG_LEVEL", level, 1);
+
+    // Record debug mode change
+    std::ofstream dbg(debug_log_path_, std::ios::app);
+    if (dbg.is_open()) {
+        dbg << (enable_debug ? "Debug mode enabled" : "Debug mode disabled") << std::endl;
+    }
 }
 
 std::string DaemonTernaryFissionServer::getWorkingDirectory() const {


### PR DESCRIPTION
## Summary
- track debug-mode state via atomic flag in `DaemonTernaryFissionServer`
- configure logging and log metrics when debug mode is enabled

## Testing
- `make` *(fails: Package 'jsoncpp' not found; readPIDFromFile const mismatch)*
- `make test`
- `make qa` *(fails: missing headers and clang-tidy not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68956e694338832b98f662d6f9e3ee39