### PR TITLE
Add system metrics sampling and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,16 @@ go-build:
 # =============================================================================
 # TEST AND QA
 # =============================================================================
-test:
-	@echo "✓ Test target stubbed. (Unit tests TBD)"
+TEST_BIN := tests/system_metrics_test
+
+test: $(TEST_BIN)
+	./$(TEST_BIN)
+
+$(TEST_BIN): tests/system_metrics_test.cpp src/cpp/system.metrics.cpp | tests
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS) $(LIBS)
+
+tests:
+	@mkdir -p tests
 
 qa:
 	@which cppcheck && cppcheck $(CPP_SRC_DIR) --enable=all --suppress=missingIncludeSystem || echo "cppcheck not installed"

--- a/include/system.metrics.h
+++ b/include/system.metrics.h
@@ -1,0 +1,21 @@
+#ifndef SYSTEM_METRICS_H
+#define SYSTEM_METRICS_H
+
+#include <cstdint>
+
+namespace TernaryFission {
+
+struct MemoryUsage {
+    double percent;
+    uint64_t peak_bytes;
+};
+
+// We sample CPU usage over a short interval and return percentage [0,100]
+double getCPUUsagePercent();
+
+// We retrieve current memory usage percent and peak resident set size
+MemoryUsage getMemoryUsage();
+
+} // namespace TernaryFission
+
+#endif // SYSTEM_METRICS_H

--- a/src/cpp/http.ternary.fission.server.cpp
+++ b/src/cpp/http.ternary.fission.server.cpp
@@ -29,6 +29,7 @@
 
 #include "http.ternary.fission.server.h"
 #include "physics.utilities.h"
+#include "system.metrics.h"
 #include <iostream>
 #include <sstream>
 #include <fstream>
@@ -707,9 +708,10 @@ SystemStatusResponse HTTPTernaryFissionServer::generateSystemStatus() const {
     }
     
     // We calculate system resource usage
-    status.cpu_usage_percent = 0.0;  // TODO: Implement actual CPU monitoring
-    status.memory_usage_percent = 0.0;  // TODO: Implement actual memory monitoring
-    status.peak_memory_usage_bytes = 0;  // TODO: Implement memory tracking
+    status.cpu_usage_percent = getCPUUsagePercent();
+    MemoryUsage mem = getMemoryUsage();
+    status.memory_usage_percent = mem.percent;
+    status.peak_memory_usage_bytes = mem.peak_bytes;
     
     return status;
 }

--- a/src/cpp/system.metrics.cpp
+++ b/src/cpp/system.metrics.cpp
@@ -1,0 +1,108 @@
+#include "system.metrics.h"
+#include <fstream>
+#include <sstream>
+#include <thread>
+#include <chrono>
+#ifdef __linux__
+#include <unistd.h>
+#elif defined(__APPLE__)
+#include <mach/mach.h>
+#include <sys/sysctl.h>
+#endif
+
+namespace TernaryFission {
+namespace {
+#ifdef __linux__
+std::pair<uint64_t, uint64_t> readProcStat() {
+    std::ifstream file("/proc/stat");
+    std::string cpu;
+    uint64_t user = 0, nice = 0, system = 0, idle = 0;
+    uint64_t iowait = 0, irq = 0, softirq = 0, steal = 0;
+    if (file) {
+        file >> cpu >> user >> nice >> system >> idle >> iowait >> irq >> softirq >> steal;
+    }
+    uint64_t idleAll = idle + iowait;
+    uint64_t nonIdle = user + nice + system + irq + softirq + steal;
+    uint64_t total = idleAll + nonIdle;
+    return {total, idleAll};
+}
+#elif defined(__APPLE__)
+std::pair<uint64_t, uint64_t> readHostCPU() {
+    host_cpu_load_info_data_t info;
+    mach_msg_type_number_t count = HOST_CPU_LOAD_INFO_COUNT;
+    if (host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO, (host_info_t)&info, &count) != KERN_SUCCESS) {
+        return {0, 0};
+    }
+    uint64_t user = info.cpu_ticks[CPU_STATE_USER];
+    uint64_t nice = info.cpu_ticks[CPU_STATE_NICE];
+    uint64_t system = info.cpu_ticks[CPU_STATE_SYSTEM];
+    uint64_t idle = info.cpu_ticks[CPU_STATE_IDLE];
+    uint64_t total = user + nice + system + idle;
+    return {total, idle};
+}
+#endif
+} // anonymous namespace
+
+double getCPUUsagePercent() {
+#ifdef __linux__
+    auto [total1, idle1] = readProcStat();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    auto [total2, idle2] = readProcStat();
+    uint64_t totald = total2 - total1;
+    uint64_t idled = idle2 - idle1;
+    if (totald == 0) return 0.0;
+    return (static_cast<double>(totald - idled) * 100.0) / totald;
+#elif defined(__APPLE__)
+    auto [total1, idle1] = readHostCPU();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    auto [total2, idle2] = readHostCPU();
+    uint64_t totald = total2 - total1;
+    uint64_t idled = idle2 - idle1;
+    if (totald == 0) return 0.0;
+    return (static_cast<double>(totald - idled) * 100.0) / totald;
+#else
+    return 0.0;
+#endif
+}
+
+MemoryUsage getMemoryUsage() {
+    MemoryUsage usage{0.0, 0};
+#ifdef __linux__
+    std::ifstream status("/proc/self/status");
+    std::string line;
+    uint64_t rss_kb = 0, hwm_kb = 0;
+    while (std::getline(status, line)) {
+        if (line.rfind("VmRSS:", 0) == 0) {
+            std::istringstream iss(line.substr(6));
+            iss >> rss_kb;
+        } else if (line.rfind("VmHWM:", 0) == 0) {
+            std::istringstream iss(line.substr(6));
+            iss >> hwm_kb;
+        }
+    }
+    uint64_t rss_bytes = rss_kb * 1024;
+    uint64_t hwm_bytes = hwm_kb * 1024;
+    long pages = sysconf(_SC_PHYS_PAGES);
+    long page_size = sysconf(_SC_PAGE_SIZE);
+    uint64_t total = (pages > 0 && page_size > 0) ? static_cast<uint64_t>(pages) * static_cast<uint64_t>(page_size) : 0;
+    double percent = total ? (static_cast<double>(rss_bytes) * 100.0) / total : 0.0;
+    usage.percent = percent;
+    usage.peak_bytes = hwm_bytes;
+#elif defined(__APPLE__)
+    mach_task_basic_info_data_t info;
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info, &count) == KERN_SUCCESS) {
+        uint64_t rss = info.resident_size;
+        uint64_t peak = info.resident_size_max;
+        uint64_t phys_mem = 0;
+        size_t size = sizeof(phys_mem);
+        sysctlbyname("hw.memsize", &phys_mem, &size, NULL, 0);
+        double percent = phys_mem ? (static_cast<double>(rss) * 100.0) / phys_mem : 0.0;
+        usage.percent = percent;
+        usage.peak_bytes = peak;
+    }
+#endif
+    return usage;
+}
+
+} // namespace TernaryFission

--- a/tests/system_metrics_test.cpp
+++ b/tests/system_metrics_test.cpp
@@ -1,0 +1,29 @@
+#include "system.metrics.h"
+#include <thread>
+#include <cassert>
+#include <iostream>
+#include <chrono>
+
+using namespace TernaryFission;
+
+int main() {
+    // We create CPU load to ensure non-zero usage
+    std::thread busy([](){
+        volatile uint64_t x = 0;
+        auto end = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+        while (std::chrono::steady_clock::now() < end) { x++; }
+    });
+    double cpu = getCPUUsagePercent();
+    busy.join();
+    if (cpu <= 0.0) {
+        std::cerr << "CPU usage percent should be > 0, got " << cpu << std::endl;
+        return 1;
+    }
+    MemoryUsage mem = getMemoryUsage();
+    if (mem.percent <= 0.0 || mem.peak_bytes == 0) {
+        std::cerr << "Memory metrics not collected" << std::endl;
+        return 1;
+    }
+    std::cout << "cpu=" << cpu << " mem%=" << mem.percent << " peak=" << mem.peak_bytes << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Sample CPU usage from `/proc/stat` on Linux and `host_statistics` on macOS
- Track memory usage and peak RSS using platform APIs
- Populate SystemStatusResponse with CPU and memory metrics
- Add test ensuring metrics return non-zero values

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68956e6ac5e4832b8de859a250862de7