### PR TITLE
Make system status generation method const

### DIFF
--- a/include/http.ternary.fission.server.h
+++ b/include/http.ternary.fission.server.h
@@ -221,7 +221,7 @@ private:
     
     // We collect and manage server metrics
     void collectMetrics();                     // Metrics collection worker
-    SystemStatusResponse generateSystemStatus(); // Generate status response
+    SystemStatusResponse generateSystemStatus() const; // Generate status response
     void updateFieldStatistics();             // Update field statistics
     
     // We provide physics engine integration


### PR DESCRIPTION
## Summary
- make generateSystemStatus() a const method in the HTTP server header
- confirm implementation already uses const signature

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689579232bbc832b81baf2b092c4fd7e