### PR TITLE
Return HTTP metrics by const reference

### DIFF
--- a/include/http.ternary.fission.server.h
+++ b/include/http.ternary.fission.server.h
@@ -282,7 +282,7 @@ public:
      * We get current server performance metrics
      * This method returns complete server statistics and performance data
      */
-    HTTPServerMetrics getMetrics() const;
+    const HTTPServerMetrics& getMetrics() const;
     
     /**
      * We get current system status information

--- a/src/cpp/http.ternary.fission.server.cpp
+++ b/src/cpp/http.ternary.fission.server.cpp
@@ -410,7 +410,7 @@ void HTTPTernaryFissionServer::setSimulationEngine(std::shared_ptr<TernaryFissio
  * We get current server performance metrics
  * This method returns complete server statistics and performance data
  */
-HTTPServerMetrics HTTPTernaryFissionServer::getMetrics() const {
+const HTTPServerMetrics& HTTPTernaryFissionServer::getMetrics() const {
     return *metrics_;
 }
 


### PR DESCRIPTION
## Summary
- Return HTTP server metrics by const reference instead of copying

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689579222508832b92935e4961757ff7