### PR TITLE
Guard SSL server code behind CPPHTTPLIB_OPENSSL_SUPPORT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,15 @@ ifeq ($(PLATFORM), macos)
         CXXFLAGS += -I$(OPENSSL_PREFIX)/include -I$(JSONCPP_PREFIX)/include
         LDFLAGS += -L$(OPENSSL_PREFIX)/lib -L$(JSONCPP_PREFIX)/lib
         LIBS += -lssl -lcrypto -ljsoncpp -framework Security -framework CoreFoundation -lproc
+        CXXFLAGS += -DCPPHTTPLIB_OPENSSL_SUPPORT
 endif
 
 ifeq ($(PLATFORM), linux)
-	CXXFLAGS += $(shell pkg-config --cflags openssl jsoncpp)
-	LDFLAGS += $(shell pkg-config --libs openssl jsoncpp)
-	CXXFLAGS += -DLINUX
-	CFLAGS += -DLINUX
+        CXXFLAGS += $(shell pkg-config --cflags openssl jsoncpp)
+        LDFLAGS += $(shell pkg-config --libs openssl jsoncpp)
+        CXXFLAGS += -DLINUX
+        CFLAGS += -DLINUX
+        CXXFLAGS += -DCPPHTTPLIB_OPENSSL_SUPPORT
 endif
 
 CXXFLAGS += -DVERSION=\"$(VERSION)\" -DBUILD_DATE=\"$(BUILD_DATE)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"

--- a/include/http.ternary.fission.server.h
+++ b/include/http.ternary.fission.server.h
@@ -149,7 +149,9 @@ class HTTPTernaryFissionServer {
 private:
     std::unique_ptr<ConfigurationManager> config_manager_;     // Configuration management
     std::unique_ptr<httplib::Server> http_server_;            // HTTP server instance
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
     std::unique_ptr<httplib::SSLServer> https_server_;        // HTTPS server instance
+#endif
     std::shared_ptr<TernaryFissionSimulationEngine> simulation_engine_; // Physics engine
     std::mutex simulation_mutex_;                // Simulation state synchronization
     
@@ -217,7 +219,9 @@ private:
     // We implement SSL/TLS certificate management  
     bool loadSSLCertificates();                // Load SSL certificates
     bool validateSSLCertificate(const std::string& cert_path); // Validate certificate
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
     void setupSSLServer();                     // Configure HTTPS server
+#endif
     
     // We collect and manage server metrics
     void collectMetrics();                     // Metrics collection worker


### PR DESCRIPTION
## Summary
- Conditionally compile the HTTPS server member and setup helper when cpp-httplib is built without OpenSSL.
- Protect server initialization, start/stop logic and middleware with `CPPHTTPLIB_OPENSSL_SUPPORT` to avoid referencing `httplib::SSLServer` when SSL is disabled.
- Define `CPPHTTPLIB_OPENSSL_SUPPORT` in the Makefile for macOS and Linux builds so SSL features are enabled when OpenSSL is present.

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6895790b5abc832b9d0637970b0a7d85