### PR TITLE
Add verbose logging output configuration flag

### DIFF
--- a/include/config.ternary.fission.server.h
+++ b/include/config.ternary.fission.server.h
@@ -133,6 +133,7 @@ struct LoggingConfiguration {
     int max_log_file_size = 104857600;         // Maximum log file size (100MB)
     int log_rotation_count = 10;               // Number of rotated log files to keep
     bool enable_json_logging = false;          // Enable structured JSON logging
+    bool verbose_output = false;               // Enable verbose logging output
     std::string log_timestamp_format = "%Y-%m-%d %H:%M:%S"; // Log timestamp format
 };
 

--- a/src/cpp/config.ternary.fission.server.cpp
+++ b/src/cpp/config.ternary.fission.server.cpp
@@ -315,6 +315,7 @@ bool ConfigurationManager::parseLoggingConfiguration() {
     logging_config_.max_log_file_size = getConfigInt("max_log_file_size", 104857600);
     logging_config_.log_rotation_count = getConfigInt("log_rotation_count", 10);
     logging_config_.enable_json_logging = getConfigBool("enable_json_logging", false);
+    logging_config_.verbose_output = getConfigBool("verbose_output", false);
     logging_config_.log_timestamp_format = getConfigValue("log_timestamp_format", "%Y-%m-%d %H:%M:%S");
     
     return true;
@@ -596,6 +597,11 @@ void ConfigurationManager::processEnvironmentOverrides() {
     std::string env_log_level = getEnvironmentVariable("TERNARY_LOG_LEVEL");
     if (!env_log_level.empty()) {
         logging_config_.log_level = env_log_level;
+    }
+
+    std::string env_verbose_output = getEnvironmentVariable("TERNARY_VERBOSE_OUTPUT");
+    if (!env_verbose_output.empty()) {
+        logging_config_.verbose_output = (env_verbose_output == "true" || env_verbose_output == "1");
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `verbose_output` toggle to `LoggingConfiguration` for detailed log output control
- Parse and store `verbose_output` from configuration files and environment variable overrides

## Testing
- `make test` *(fails: Package jsoncpp was not found; No rule to make target 'build', needed by 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6895811f8520832bbd300ac27f0af2a3