### PR TITLE
Expose simulation engine JSON API interfaces

### DIFF
--- a/include/http.ternary.fission.server.h
+++ b/include/http.ternary.fission.server.h
@@ -168,8 +168,8 @@ private:
     std::atomic<int64_t> field_id_counter_;     // Field ID generation counter
     
     // We handle WebSocket connections
-    std::map<std::string, std::unique_ptr<WebSocketConnection>> websocket_connections_;
-    std::mutex websocket_mutex_;                // WebSocket synchronization
+      std::map<std::string, std::unique_ptr<WebSocketConnection>> websocket_connections_;
+      mutable std::mutex websocket_mutex_;                // WebSocket synchronization
     std::thread websocket_broadcast_thread_;    // WebSocket broadcast worker
     std::atomic<bool> websocket_broadcasting_;  // WebSocket broadcast control
     

--- a/src/cpp/http.ternary.fission.server.cpp
+++ b/src/cpp/http.ternary.fission.server.cpp
@@ -1229,11 +1229,9 @@ void HTTPTernaryFissionServer::handleSimulationReset(const httplib::Request& req
 }
 
 // Additional forward declaration for full verifyConservationLaws signature
-namespace TernaryFission {
-    bool verifyConservationLaws(const TernaryFissionEvent& event,
-                                double energy_tolerance,
-                                double momentum_tolerance);
-}
+bool verifyConservationLaws(const TernaryFissionEvent& event,
+                            double energy_tolerance,
+                            double momentum_tolerance);
 
 void HTTPTernaryFissionServer::handleFissionCalculation(const httplib::Request& req, httplib::Response& res) {
     Json::Value body;


### PR DESCRIPTION
## Summary
- declare JSON-based control and status methods in `TernaryFissionSimulationEngine`
- fix HTTP server build by removing redundant namespace and making WebSocket mutex mutable

## Testing
- `make build/release/http.ternary.fission.server.o`

------
https://chatgpt.com/codex/tasks/task_e_689581e7032c832b8a4d52b04de13937