### PR TITLE
Expose simulation engine metrics

### DIFF
--- a/include/ternary.fission.simulation.engine.h
+++ b/include/ternary.fission.simulation.engine.h
@@ -85,6 +85,7 @@ public:
      * @return: Complete ternary fission event structure
      */
     TernaryFissionEvent simulateTernaryFissionEvent(double parent_mass, double excitation_energy);
+    TernaryFissionEvent simulateTernaryFissionEvent();
     Json::Value simulateTernaryFissionEventAPI(const Json::Value& request);
 
     /**
@@ -135,6 +136,10 @@ public:
      * @return: Current performance metrics
      */
     PerformanceMetrics getCurrentMetrics() const;
+
+    uint64_t getTotalEventsSimulated() const;
+    uint64_t getTotalEnergyFieldsCreated() const;
+    double getTotalComputationTimeSeconds() const;
 
     /**
      * Set number of worker threads


### PR DESCRIPTION
## Summary
- Declare overload to simulate ternary fission events with default parameters
- Expose total events, energy fields, and computation time metrics
- Leave JSON API endpoints available for server integration

## Testing
- `g++ -std=c++17 -Iinclude -Ithird_party/cpp-httplib $(pkg-config --cflags openssl jsoncpp) -c src/cpp/http.ternary.fission.server.cpp -o /tmp/http_server.o`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6895852403bc832bae7e0604dc9e478e