### PR TITLE
Expose verifyConservationLaws tolerances in header

### DIFF
--- a/include/physics.utilities.h
+++ b/include/physics.utilities.h
@@ -100,9 +100,13 @@ double calculateEntropy(std::size_t memory_bytes, std::uint64_t cpu_cycles);
  * We check energy, momentum, mass, and charge conservation
  *
  * @param event: The fission event to verify
+ * @param energy_tolerance: Allowed deviation in energy conservation
+ * @param momentum_tolerance: Allowed deviation in momentum conservation
  * @return: true if all conservation laws are satisfied within tolerance
  */
-bool verifyConservationLaws(const TernaryFissionEvent& event);
+bool verifyConservationLaws(const TernaryFissionEvent& event,
+                            double energy_tolerance,
+                            double momentum_tolerance);
 
 /*
  * Allocate memory and CPU cycles to represent energy field

--- a/src/cpp/http.ternary.fission.server.cpp
+++ b/src/cpp/http.ternary.fission.server.cpp
@@ -1228,11 +1228,6 @@ void HTTPTernaryFissionServer::handleSimulationReset(const httplib::Request& req
     }
 }
 
-// Additional forward declaration for full verifyConservationLaws signature
-bool verifyConservationLaws(const TernaryFissionEvent& event,
-                            double energy_tolerance,
-                            double momentum_tolerance);
-
 void HTTPTernaryFissionServer::handleFissionCalculation(const httplib::Request& req, httplib::Response& res) {
     Json::Value body;
     if (!parseJSONRequest(req, body)) {


### PR DESCRIPTION
## Summary
- declare verifyConservationLaws with explicit energy and momentum tolerances
- remove ad hoc forward declaration from HTTP server source

## Testing
- `g++ -std=c++17 -Wall -Wextra -Wpedantic -Iinclude -Ithird_party/cpp-httplib $(pkg-config --cflags openssl jsoncpp) -c src/cpp/http.ternary.fission.server.cpp -o /tmp/http.o`


------
https://chatgpt.com/codex/tasks/task_e_689586fe4f54832b914d83c1387b4f23