### PR TITLE
Reorder server metrics initialization

### DIFF
--- a/src/cpp/http.ternary.fission.server.cpp
+++ b/src/cpp/http.ternary.fission.server.cpp
@@ -237,8 +237,8 @@ HTTPTernaryFissionServer::HTTPTernaryFissionServer(std::unique_ptr<Configuration
     , start_time_(std::chrono::system_clock::now())
     , field_id_counter_(1)
     , websocket_broadcasting_(false)
-    , metrics_collecting_(false)
-    , metrics_(std::make_unique<HTTPServerMetrics>()) {
+    , metrics_(std::make_unique<HTTPServerMetrics>())
+    , metrics_collecting_(false) {
     
     // We initialize SSL library for certificate handling
     SSL_library_init();


### PR DESCRIPTION
## Summary
- fix HTTPTernaryFissionServer initializer order so metrics_ comes before metrics_collecting_

## Testing
- `make all` *(fails: ‘DaemonTernaryFissionServer’ has no member named ‘getConfiguration’)*
- `g++ -std=c++17 -Wall -Wextra -Wpedantic -Iinclude -Ithird_party/cpp-httplib $(pkg-config --cflags jsoncpp openssl) -c src/cpp/http.ternary.fission.server.cpp -o /tmp/http.o`

------
https://chatgpt.com/codex/tasks/task_e_68958ee51038832bbaf773fd4b6791e3