### PR TITLE
Add daemon server configuration interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,21 +36,21 @@ ifeq ($(UNAME_S),Darwin)
     PLATFORM := macos
     # We detect Homebrew installation paths for macOS
     ifeq ($(UNAME_M),arm64)
-        HOMEBREW_PREFIX := /opt/homebrew
+	HOMEBREW_PREFIX := /opt/homebrew
     else
-        HOMEBREW_PREFIX := /usr/local
+	HOMEBREW_PREFIX := /usr/local
     endif
     # We check if OpenSSL is installed via Homebrew
     OPENSSL_PREFIX := $(HOMEBREW_PREFIX)/opt/openssl@3
     ifneq ($(wildcard $(OPENSSL_PREFIX)/include/openssl/evp.h),)
-        OPENSSL_FOUND := true
-        OPENSSL_INCLUDE := -I$(OPENSSL_PREFIX)/include
-        OPENSSL_LIB := -L$(OPENSSL_PREFIX)/lib
+	OPENSSL_FOUND := true
+	OPENSSL_INCLUDE := -I$(OPENSSL_PREFIX)/include
+	OPENSSL_LIB := -L$(OPENSSL_PREFIX)/lib
     else
-        # We fall back to system OpenSSL if Homebrew version not found
-        OPENSSL_FOUND := false
-        OPENSSL_INCLUDE :=
-        OPENSSL_LIB :=
+	# We fall back to system OpenSSL if Homebrew version not found
+	OPENSSL_FOUND := false
+	OPENSSL_INCLUDE :=
+	OPENSSL_LIB :=
     endif
 else ifeq ($(UNAME_S),Linux)
     PLATFORM := linux
@@ -97,9 +97,9 @@ PROFILE_FLAGS := $(COMMON_FLAGS) -O2 -pg -DPROFILE
 # We adjust march flag for macOS ARM
 ifeq ($(PLATFORM),macos)
     ifeq ($(UNAME_M),arm64)
-        RELEASE_FLAGS := $(COMMON_FLAGS) -O3 -DNDEBUG -flto -mcpu=apple-m1
+	RELEASE_FLAGS := $(COMMON_FLAGS) -O3 -DNDEBUG -flto -mcpu=apple-m1
     else
-        RELEASE_FLAGS := $(COMMON_FLAGS) -O3 -DNDEBUG -march=native -flto
+	RELEASE_FLAGS := $(COMMON_FLAGS) -O3 -DNDEBUG -march=native -flto
     endif
 else
     RELEASE_FLAGS := $(COMMON_FLAGS) -O3 -DNDEBUG -march=native -flto
@@ -124,7 +124,7 @@ GO_SOURCES := $(wildcard $(SRC_DIR)/go/*.go)
 
 # Object files (exclude main files to avoid multiple main definitions)
 CPP_OBJS := $(BUILD_DIR)/$(BUILD_TYPE)/physics.utilities.o \
-            $(BUILD_DIR)/$(BUILD_TYPE)/ternary.fission.simulation.engine.o
+	    $(BUILD_DIR)/$(BUILD_TYPE)/ternary.fission.simulation.engine.o
 
 # Executables
 CPP_MAIN := $(BIN_DIR)/ternary-fission
@@ -276,13 +276,16 @@ endif
 $(CPP_MAIN): $(CPP_OBJS) $(SRC_DIR)/cpp/main.ternary.fission.application.cpp | $(BIN_DIR)
 ifeq ($(BUILD_TYPE),debug)
 	@echo "Building C++ simulation engine (DEBUG)..."
-	$(CXX) $(DEBUG_FLAGS) $(VERSION_FLAGS) $(SRC_DIR)/cpp/main.ternary.fission.application.cpp $(CPP_OBJS) -o $@ $(LDFLAGS)
+	$(CXX) $(DEBUG_FLAGS) $(VERSION_FLAGS) $(SRC_DIR)/cpp/main.ternary.fission.application.cpp $(CPP_OBJS) \
+	$(SRC_DIR)/cpp/daemon.ternary.fission.server.cpp $(SRC_DIR)/cpp/config.ternary.fission.server.cpp -o $@ $(LDFLAGS)
 else ifeq ($(BUILD_TYPE),profile)
 	@echo "Building C++ simulation engine (PROFILE)..."
-	$(CXX) $(PROFILE_FLAGS) $(VERSION_FLAGS) $(SRC_DIR)/cpp/main.ternary.fission.application.cpp $(CPP_OBJS) -o $@ $(LDFLAGS)
+	$(CXX) $(PROFILE_FLAGS) $(VERSION_FLAGS) $(SRC_DIR)/cpp/main.ternary.fission.application.cpp $(CPP_OBJS) \
+	$(SRC_DIR)/cpp/daemon.ternary.fission.server.cpp $(SRC_DIR)/cpp/config.ternary.fission.server.cpp -o $@ $(LDFLAGS)
 else
 	@echo "Building C++ simulation engine (RELEASE)..."
-	$(CXX) $(RELEASE_FLAGS) $(VERSION_FLAGS) $(SRC_DIR)/cpp/main.ternary.fission.application.cpp $(CPP_OBJS) -o $@ $(LDFLAGS)
+	$(CXX) $(RELEASE_FLAGS) $(VERSION_FLAGS) $(SRC_DIR)/cpp/main.ternary.fission.application.cpp $(CPP_OBJS) \
+	$(SRC_DIR)/cpp/daemon.ternary.fission.server.cpp $(SRC_DIR)/cpp/config.ternary.fission.server.cpp -o $@ $(LDFLAGS)
 endif
 	@echo "C++ build complete: $@"
 

--- a/include/config.ternary.fission.server.h
+++ b/include/config.ternary.fission.server.h
@@ -1,0 +1,19 @@
+#ifndef CONFIG_TERNARY_FISSION_SERVER_H
+#define CONFIG_TERNARY_FISSION_SERVER_H
+
+#include "physics.utilities.h"
+
+namespace TernaryFission {
+
+class Configuration {
+public:
+    Configuration();
+    const EnergyFieldConfig& getPhysicsConfig() const;
+
+private:
+    EnergyFieldConfig physics_config_;
+};
+
+} // namespace TernaryFission
+
+#endif // CONFIG_TERNARY_FISSION_SERVER_H

--- a/include/daemon.ternary.fission.server.h
+++ b/include/daemon.ternary.fission.server.h
@@ -1,0 +1,23 @@
+#ifndef DAEMON_TERNARY_FISSION_SERVER_H
+#define DAEMON_TERNARY_FISSION_SERVER_H
+
+#include <memory>
+
+#include "config.ternary.fission.server.h"
+
+namespace TernaryFission {
+
+class DaemonTernaryFissionServer {
+public:
+    DaemonTernaryFissionServer();
+    explicit DaemonTernaryFissionServer(std::shared_ptr<Configuration> config);
+
+    std::shared_ptr<Configuration> getConfiguration() const;
+
+private:
+    std::shared_ptr<Configuration> configuration_;
+};
+
+} // namespace TernaryFission
+
+#endif // DAEMON_TERNARY_FISSION_SERVER_H

--- a/src/cpp/config.ternary.fission.server.cpp
+++ b/src/cpp/config.ternary.fission.server.cpp
@@ -1,0 +1,11 @@
+#include "config.ternary.fission.server.h"
+
+namespace TernaryFission {
+
+Configuration::Configuration() : physics_config_() {}
+
+const EnergyFieldConfig& Configuration::getPhysicsConfig() const {
+    return physics_config_;
+}
+
+} // namespace TernaryFission

--- a/src/cpp/daemon.ternary.fission.server.cpp
+++ b/src/cpp/daemon.ternary.fission.server.cpp
@@ -1,0 +1,19 @@
+#include "daemon.ternary.fission.server.h"
+
+namespace TernaryFission {
+
+DaemonTernaryFissionServer::DaemonTernaryFissionServer()
+    : configuration_(std::make_shared<Configuration>()) {}
+
+DaemonTernaryFissionServer::DaemonTernaryFissionServer(std::shared_ptr<Configuration> config)
+    : configuration_(std::move(config)) {
+    if (!configuration_) {
+        configuration_ = std::make_shared<Configuration>();
+    }
+}
+
+std::shared_ptr<Configuration> DaemonTernaryFissionServer::getConfiguration() const {
+    return configuration_;
+}
+
+} // namespace TernaryFission

--- a/src/cpp/main.ternary.fission.application.cpp
+++ b/src/cpp/main.ternary.fission.application.cpp
@@ -22,6 +22,7 @@
 #include "ternary.fission.simulation.engine.h"
 #include "physics.utilities.h"
 #include "physics.constants.definitions.h"
+#include "daemon.ternary.fission.server.h"
 
 #include <iostream>
 #include <iomanip>
@@ -137,6 +138,11 @@ int main(int argc, char* argv[]) {
     if (stat(log_dir.c_str(), &st) == -1) {
         mkdir(log_dir.c_str(), 0700);
     }
+
+    // Retrieve physics configuration from the daemon server
+    DaemonTernaryFissionServer daemon_server;
+    auto daemon_config = daemon_server.getConfiguration();
+    initializePhysicsUtilities(&daemon_config->getPhysicsConfig());
 
     // Print simulation parameters
     std::cout << "Simulation Parameters:" << std::endl;


### PR DESCRIPTION
## Summary
- add `Configuration` and `DaemonTernaryFissionServer` classes for shared physics configuration access
- wire main application to initialize physics utilities through the daemon server
- build system updated to compile new server sources

## Testing
- `make cpp-build`


------
https://chatgpt.com/codex/tasks/task_e_6895930c6544832bb85497b967940efb