### PR TITLE
build: close missing conditionals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ else
     OPENSSL_FOUND := false
     OPENSSL_INCLUDE :=
     OPENSSL_LIB :=
+endif
 
 # =============================================================================
 # PLATFORM DETECTION
@@ -117,12 +118,14 @@ ifeq ($(PLATFORM),macos)
     endif
 else
     RELEASE_FLAGS := $(COMMON_FLAGS) -O3 -DNDEBUG -march=native -flto
-ifeq ($(PLATFORM), linux)
+    ifeq ($(PLATFORM), linux)
         CXXFLAGS += $(shell pkg-config --cflags openssl jsoncpp)
         LDFLAGS += $(shell pkg-config --libs openssl jsoncpp)
         CXXFLAGS += -DLINUX
         CFLAGS += -DLINUX
         CXXFLAGS += -DCPPHTTPLIB_OPENSSL_SUPPORT
+
+    endif
 
 endif
 


### PR DESCRIPTION
## Summary
- close unclosed OS detection block in Makefile
- fix macOS/Linux release flag conditional and indent

## Testing
- `make` *(fails: Package jsoncpp was not found; include header errors)*
- `make cpp-build` *(fails: No rule to make target 'cpp-build')*
- `make go-build`

------
https://chatgpt.com/codex/tasks/task_e_6895986ee3dc832b90d50b27db6608d0