### PR TITLE
config: remove redundant header guard

### DIFF
--- a/include/config.ternary.fission.server.h
+++ b/include/config.ternary.fission.server.h
@@ -1,19 +1,3 @@
-#ifndef CONFIG_TERNARY_FISSION_SERVER_H
-#define CONFIG_TERNARY_FISSION_SERVER_H
-
-#include "physics.utilities.h"
-
-namespace TernaryFission {
-
-class Configuration {
-public:
-    Configuration();
-    const EnergyFieldConfig& getPhysicsConfig() const;
-
-private:
-    EnergyFieldConfig physics_config_;
-};
-
 /*
  * File: include/config.ternary.fission.server.h
  * Author: bthlops (David StJ)
@@ -38,7 +22,6 @@ private:
  * - Environment variable overrides follow hybrid configuration strategy
  * - Next: Integration with daemon and HTTP server classes for complete service
  */
-
 #ifndef CONFIG_TERNARY_FISSION_SERVER_H
 #define CONFIG_TERNARY_FISSION_SERVER_H
 


### PR DESCRIPTION
## Summary
- drop placeholder Configuration class and duplicate header guard
- keep ConfigurationManager and related structures under a single guard

## Testing
- `make cpp-build` *(fails: No rule to make target 'cpp-build')*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*

------
https://chatgpt.com/codex/tasks/task_e_6896267839ac832bae6bcc7311adf283