### PR TITLE
scripts: add SSL certificate manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,15 @@ sudo nano /etc/ternary-fission/ternary_fission.conf
 
 # Key settings
 api_port=8080
-events_per_second=5.0  
+events_per_second=5.0
 max_energy_field=1000.0
 log_level=info
+```
+
+### SSL Certificate Management
+```bash
+# Generate a self-signed certificate for local testing
+./scripts/ssl-manager.sh --cn localhost --days 365
 ```
 
 ## 📊 API Documentation

--- a/scripts/ssl-manager.sh
+++ b/scripts/ssl-manager.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# File: scripts/ssl-manager.sh
+# Author: ChatGPT (OpenAI)
+# Date: August 8, 2025
+# Title: SSL Certificate Management Utility
+# Purpose: Generate self-signed certificates for local development and testing
+# Reason: Provide a simple way to create certificates without external dependencies
+#
+# Change Log:
+# 2025-08-08: Initial creation with CN and expiration options
+#
+set -e
+
+show_usage() {
+    cat <<'USAGE'
+SSL Certificate Management Utility
+Usage: $0 [--cn COMMON_NAME] [--days DAYS]
+Options:
+    --cn COMMON_NAME  Common Name for certificate (default: localhost)
+    --days DAYS       Validity period in days (default: 365)
+USAGE
+}
+
+CN="localhost"
+DAYS=365
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --cn)
+            CN="$2"
+            shift 2
+            ;;
+        --days)
+            DAYS="$2"
+            shift 2
+            ;;
+        --help|-h)
+            show_usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_usage
+            exit 1
+            ;;
+    esac
+done
+
+CERT_DIR="certs"
+mkdir -p "$CERT_DIR"
+
+openssl req -x509 -newkey rsa:4096 -sha256 -days "$DAYS" -nodes \
+    -keyout "$CERT_DIR/server.key" -out "$CERT_DIR/server.crt" \
+    -subj "/CN=$CN"
+
+echo "Certificate and key generated in $CERT_DIR"


### PR DESCRIPTION
## Summary
- add `ssl-manager.sh` utility for generating self-signed certificates with configurable common name and expiration
- document certificate script usage in README

## Testing
- `make cpp-build` *(fails: No rule to make target 'cpp-build')*
- `make go-build` *(fails: Package jsoncpp was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689627cae404832bbdb360c51fb9be2f