### PR TITLE
config: remove legacy configuration stubs

### DIFF
--- a/src/cpp/config.ternary.fission.server.cpp
+++ b/src/cpp/config.ternary.fission.server.cpp
@@ -1,14 +1,3 @@
-
-#include "config.ternary.fission.server.h"
-
-namespace TernaryFission {
-
-Configuration::Configuration() : physics_config_() {}
-
-const EnergyFieldConfig& Configuration::getPhysicsConfig() const {
-    return physics_config_;
-}
-
 /*
  * File: src/cpp/config.ternary.fission.server.cpp
  * Author: bthlops (David StJ)


### PR DESCRIPTION
## Summary
- remove obsolete Configuration stubs and duplicate include from config manager
- consolidate includes and target TernaryFission::ConfigurationManager implementations

## Testing
- `make cpp-build` *(fails: No rule to make target `cpp-build`)*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target `cpp-test`)*
- `make static-analysis` *(fails: No rule to make target `static-analysis`)*

------
https://chatgpt.com/codex/tasks/task_e_689627acab30832b9ad0e6f8fdf61813