### PR TITLE
build: remove duplicate main binary rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,9 +219,6 @@ $(TEST_BUILD_DIR):
 $(BUILD_SUBDIR)/%.o: $(CPP_SRC_DIR)/%.cpp | $(BUILD_SUBDIR)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@
 
-$(CPP_MAIN): $(CPP_OBJECTS) | $(BIN_DIR)
-	$(CXX) $(CPP_OBJECTS) $(LDFLAGS) $(LIBS) -o $@
-	@echo "✓ C++ binary built: $@"
 
 # =============================================================================
 # GO BUILD


### PR DESCRIPTION
## Summary
- remove duplicate `$(CPP_MAIN)` rule in Makefile
- rely on build-type-aware rule to avoid overriding warnings

## Testing
- `make cpp-build` *(fails: No rule to make target 'cpp-build')*
- `make go-build`


------
https://chatgpt.com/codex/tasks/task_e_689634a951d8832bb46741b1f38307ae