### PR TITLE
main: integrate configuration manager into daemon startup

### DIFF
--- a/src/cpp/main.ternary.fission.application.cpp
+++ b/src/cpp/main.ternary.fission.application.cpp
@@ -208,8 +208,9 @@ int main(int argc, char* argv[]) {
 
 
     // Retrieve physics configuration from the daemon server
-    DaemonTernaryFissionServer daemon_server;
-    auto daemon_config = daemon_server.getConfiguration();
+    auto config_manager = std::make_unique<ConfigurationManager>();
+    DaemonTernaryFissionServer daemon_server(std::move(config_manager));
+    ConfigurationManager* daemon_config = daemon_server.getConfiguration();
     initializePhysicsUtilities(&daemon_config->getPhysicsConfig());
 
     // Print simulation parameters
@@ -479,7 +480,7 @@ void runDaemonMode(const std::string& config_file, const std::string& bind_ip, i
         }
 
         // Initialize physics engine
-        auto physics_config = daemon_manager->getConfiguration()->getPhysicsConfiguration();
+        const auto& physics_config = daemon_manager->getConfiguration()->getPhysicsConfig();
         auto engine = std::make_shared<TernaryFissionSimulationEngine>(
             physics_config.default_parent_mass,
             physics_config.default_excitation_energy,


### PR DESCRIPTION
## Summary
- create daemon server using a `ConfigurationManager` unique pointer and pass its configuration to physics utilities
- switch physics initialization to `getPhysicsConfig()`

## Testing
- `make cpp-build` *(fails: No rule to make target 'cpp-build')*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*
- `g++ -std=c++17 -Iinclude -I/usr/include/jsoncpp -c src/cpp/main.ternary.fission.application.cpp -o /tmp/main.o` *(fails: fatal error: httplib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689634a8967c832b920d92c1297bc78c