### PR TITLE
daemon: remove legacy constructors and expose configuration manager

### DIFF
--- a/include/daemon.ternary.fission.server.h
+++ b/include/daemon.ternary.fission.server.h
@@ -1,22 +1,3 @@
-#ifndef DAEMON_TERNARY_FISSION_SERVER_H
-#define DAEMON_TERNARY_FISSION_SERVER_H
-
-#include <memory>
-
-#include "config.ternary.fission.server.h"
-
-namespace TernaryFission {
-
-class DaemonTernaryFissionServer {
-public:
-    DaemonTernaryFissionServer();
-    explicit DaemonTernaryFissionServer(std::shared_ptr<Configuration> config);
-
-    std::shared_ptr<Configuration> getConfiguration() const;
-
-private:
-    std::shared_ptr<Configuration> configuration_;
-
 /*
  * File: include/daemon.ternary.fission.server.h
  * Author: bthlops (David StJ)
@@ -283,6 +264,12 @@ public:
      * This method updates daemon configuration while maintaining operation
      */
     bool reloadConfiguration();
+
+    /**
+     * We get daemon configuration manager
+     * This method provides access to configuration management system
+     */
+    ConfigurationManager* getConfiguration() const;
     
     /**
      * We get daemon performance statistics

--- a/src/cpp/daemon.ternary.fission.server.cpp
+++ b/src/cpp/daemon.ternary.fission.server.cpp
@@ -1,19 +1,3 @@
-#include "daemon.ternary.fission.server.h"
-
-namespace TernaryFission {
-
-DaemonTernaryFissionServer::DaemonTernaryFissionServer()
-    : configuration_(std::make_shared<Configuration>()) {}
-
-DaemonTernaryFissionServer::DaemonTernaryFissionServer(std::shared_ptr<Configuration> config)
-    : configuration_(std::move(config)) {
-    if (!configuration_) {
-        configuration_ = std::make_shared<Configuration>();
-    }
-}
-
-std::shared_ptr<Configuration> DaemonTernaryFissionServer::getConfiguration() const {
-    return configuration_;
 /*
  * File: src/cpp/daemon.ternary.fission.server.cpp
  * Author: bthlops (David StJ)
@@ -1081,6 +1065,10 @@ bool DaemonTernaryFissionServer::isAnotherInstanceRunning() const {
  */
 bool DaemonTernaryFissionServer::reloadConfiguration() {
     return config_manager_->reloadConfiguration();
+}
+
+ConfigurationManager* DaemonTernaryFissionServer::getConfiguration() const {
+    return config_manager_.get();
 }
 
 /**

--- a/src/cpp/main.ternary.fission.application.cpp
+++ b/src/cpp/main.ternary.fission.application.cpp
@@ -207,10 +207,8 @@ int main(int argc, char* argv[]) {
     }
 
 
-    // Retrieve physics configuration from the daemon server
-    DaemonTernaryFissionServer daemon_server;
-    auto daemon_config = daemon_server.getConfiguration();
-    initializePhysicsUtilities(&daemon_config->getPhysicsConfig());
+    // Initialize physics utilities using daemon configuration defaults
+    initializePhysicsUtilities();
 
     // Print simulation parameters
     std::cout << "Simulation Parameters:" << std::endl;
@@ -479,7 +477,7 @@ void runDaemonMode(const std::string& config_file, const std::string& bind_ip, i
         }
 
         // Initialize physics engine
-        auto physics_config = daemon_manager->getConfiguration()->getPhysicsConfiguration();
+        auto physics_config = daemon_manager->getConfiguration()->getPhysicsConfig();
         auto engine = std::make_shared<TernaryFissionSimulationEngine>(
             physics_config.default_parent_mass,
             physics_config.default_excitation_energy,


### PR DESCRIPTION
## Summary
- remove legacy constructors and configuration block from daemon server
- add ConfigurationManager accessor for daemon server
- adjust main application to use new configuration API

## Testing
- `make cpp-build` *(fails: No rule to make target 'cpp-build')*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*
- `g++ -std=c++17 -Iinclude -Ithird_party -c src/cpp/daemon.ternary.fission.server.cpp -o /tmp/daemon.o`

------
https://chatgpt.com/codex/tasks/task_e_689634a6dbe4832bb2984f0376d7c1bd