### PR TITLE
build: initialize build variables before object list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,17 +143,17 @@ BIN_DIR := bin
 DIST_DIR := dist
 TEST_DIR := tests
 
+BUILD_TYPE ?= release
+BUILD_SUBDIR := $(BUILD_DIR)/$(BUILD_TYPE)
+
 # Source files
 CPP_SOURCES := $(wildcard $(SRC_DIR)/cpp/*.cpp)
 CPP_HEADERS := $(wildcard $(INCLUDE_DIR)/*.h)
 GO_SOURCES := $(wildcard $(SRC_DIR)/go/*.go)
 
 # Object files (exclude main files to avoid multiple main definitions)
-CPP_OBJS := $(BUILD_DIR)/$(BUILD_TYPE)/physics.utilities.o \
-	    $(BUILD_DIR)/$(BUILD_TYPE)/ternary.fission.simulation.engine.o
-
-BUILD_TYPE ?= release
-BUILD_SUBDIR := $(BUILD_DIR)/$(BUILD_TYPE)
+CPP_OBJS := $(BUILD_SUBDIR)/physics.utilities.o \
+            $(BUILD_SUBDIR)/ternary.fission.simulation.engine.o
 
 
 CPP_SOURCES := $(wildcard $(CPP_SRC_DIR)/*.cpp)


### PR DESCRIPTION
## Summary
- Define `BUILD_TYPE` and `BUILD_SUBDIR` before `CPP_OBJS` to ensure non-empty build paths
- Update `CPP_OBJS` to use `$(BUILD_SUBDIR)` for object file locations

## Testing
- `make cpp-build` *(fails: No rule to make target 'cpp-build')*
- `make go-build` *(fails: Package 'jsoncpp', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896ec8c2884832b8f59b279e2baa5a3