### PR TITLE
daemon: remove duplicate configuration accessor

### DIFF
--- a/include/daemon.ternary.fission.server.h
+++ b/include/daemon.ternary.fission.server.h
@@ -270,12 +270,6 @@ public:
      * This method updates daemon configuration while maintaining operation
      */
     bool reloadConfiguration();
-
-    /**
-     * We get daemon configuration manager
-     * This method provides access to configuration management system
-     */
-    ConfigurationManager* getConfiguration() const;
     
     /**
      * We get daemon performance statistics


### PR DESCRIPTION
## Summary
- remove duplicate `getConfiguration` declaration from daemon server header
- ensure daemon server implementation retains single `getConfiguration` definition

## Testing
- `make cpp-build` *(fails: No rule to make target 'cpp-build')*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*
- `g++ -std=c++17 -Iinclude -c src/cpp/daemon.ternary.fission.server.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6896f6f16bdc832ba56190b3574c0e26