### PR TITLE
build: include jsoncpp development package

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -33,11 +33,14 @@ jobs:
         run: |
           if command -v sudo >/dev/null 2>&1; then
             sudo apt-get update
-            sudo apt-get install -y build-essential gcc g++ cmake make libssl-dev pkg-config
+            sudo apt-get install -y build-essential gcc g++ cmake make libssl-dev pkg-config libjsoncpp-dev
           else
             apt-get update
-            apt-get install -y build-essential gcc g++ cmake make libssl-dev pkg-config
+            apt-get install -y build-essential gcc g++ cmake make libssl-dev pkg-config libjsoncpp-dev
           fi
+
+      - name: Verify jsoncpp pkg-config
+        run: pkg-config --cflags --libs jsoncpp
 
       - name: Build C++ components
         run: make cpp-build

--- a/Dockerfile.debian12
+++ b/Dockerfile.debian12
@@ -17,10 +17,11 @@ ARG VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
-    build-essential gcc g++ cmake make pkg-config \
+    build-essential gcc g++ cmake make pkg-config libjsoncpp-dev \
     libgsl-dev libeigen3-dev libfftw3-dev libopenblas-dev \
     liblapack-dev libssl-dev libcrypto++-dev libboost-all-dev git \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && pkg-config --cflags --libs jsoncpp
 
 WORKDIR /build
 COPY include/ include/


### PR DESCRIPTION
## Summary
- add `libjsoncpp-dev` to CI build tools and verify via `pkg-config`
- install `libjsoncpp-dev` in Debian 12 Docker build and check with `pkg-config`

## Testing
- `pkg-config --cflags --libs jsoncpp`
- `make go-build`
- `make` *(fails: missing struct members in `physics.utilities.cpp`)*

------
https://chatgpt.com/codex/tasks/task_e_6897644beed4832bad78d5c901734edd