### PR TITLE
Add cpp-build target for C++ build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ TEST_BINARIES := $(FD_COUNT_TEST) $(SYSTEM_METRICS_TEST) $(INTEGRATION_TEST)
 # =============================================================================
 # TARGETS
 # =============================================================================
-.PHONY: all help clean test qa install docker release dist deb test-fd test-metrics test-integration
+.PHONY: all cpp-build help clean test qa install docker release dist deb test-fd test-metrics test-integration
 
 all: info $(CPP_MAIN) go-build
 
@@ -215,6 +215,12 @@ $(TEST_BUILD_DIR):
 $(BUILD_SUBDIR)/%.o: $(CPP_SRC_DIR)/%.cpp | $(BUILD_SUBDIR)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@
 
+
+# =============================================================================
+# C++ BUILD
+# =============================================================================
+cpp-build: $(CPP_MAIN)
+	@echo "✓ C++ components built"
 
 # =============================================================================
 # GO BUILD

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ brew install jsoncpp openssl@3 cpp-httplib
 # Build all components
 make all
 
+# Build only C++ components
+make cpp-build
+
 # The cpp-httplib header is vendored under `third_party/cpp-httplib/httplib.h` if package managers are unavailable.
 
 # Run API server


### PR DESCRIPTION
## Summary
- add dedicated `cpp-build` target for building the C++ engine
- document how to build C++ components separately

## Testing
- `make cpp-build` *(fails: EnergyField struct missing members)*
- `make go-build`


------
https://chatgpt.com/codex/tasks/task_e_689765878850832b85515a7fdc915417