### PR TITLE
cpp: cast numeric json values

### DIFF
--- a/src/cpp/http.ternary.fission.server.cpp
+++ b/src/cpp/http.ternary.fission.server.cpp
@@ -144,7 +144,7 @@ Json::Value SystemStatusResponse::toJson() const {
     json["uptime_seconds"] = static_cast<Json::Int64>(uptime_seconds);
     json["total_fission_events"] = static_cast<Json::UInt64>(total_fission_events);
     json["total_energy_simulated_mev"] = total_energy_simulated_mev;
-    json["active_energy_fields"] = active_energy_fields;
+    json["active_energy_fields"] = static_cast<Json::Int64>(active_energy_fields);
     json["peak_memory_usage_bytes"] = static_cast<Json::UInt64>(peak_memory_usage_bytes);
     json["average_calculation_time_microseconds"] = average_calc_time_microseconds;
     json["total_calculations"] = static_cast<Json::UInt64>(total_calculations);
@@ -624,7 +624,7 @@ void HTTPTernaryFissionServer::handleHealthCheck(const httplib::Request& /*req*/
     Json::Value health;
     health["status"] = "healthy";
     health["uptime_seconds"] = static_cast<Json::Int64>(uptime.count());
-    health["active_energy_fields"] = static_cast<int>(energy_fields_.size());
+    health["active_energy_fields"] = static_cast<Json::Int64>(energy_fields_.size());
     health["simulation_running"] = simulation_engine_ != nullptr;
     health["version"] = "1.1.13";
     health["author"] = "bthlops (David StJ)";
@@ -667,7 +667,7 @@ void HTTPTernaryFissionServer::handleEnergyFieldsList(const httplib::Request& /*
     
     Json::Value response;
     response["energy_fields"] = fields_array;
-    response["total_fields"] = static_cast<int>(energy_fields_.size());
+    response["total_fields"] = static_cast<Json::Int64>(energy_fields_.size());
     
     sendJSONResponse(res, 200, response);
     metrics_->incrementSuccessful();
@@ -774,7 +774,7 @@ void HTTPTernaryFissionServer::sendJSONResponse(httplib::Response& res, int stat
 void HTTPTernaryFissionServer::sendErrorResponse(httplib::Response& res, int status_code, const std::string& message) {
     Json::Value error;
     error["error"] = message;
-    error["status_code"] = status_code;
+    error["status_code"] = static_cast<Json::Int64>(status_code);
     
     auto now = std::chrono::system_clock::now();
     auto time_t = std::chrono::system_clock::to_time_t(now);
@@ -1409,9 +1409,9 @@ Json::Value HTTPTernaryFissionServer::computeFieldStatistics() const {
     int inactive_fields = total_fields - active_fields;
     double average_energy = total_fields > 0 ? total_energy / total_fields : 0.0;
 
-    stats["total_fields"] = total_fields;
-    stats["active_fields"] = active_fields;
-    stats["inactive_fields"] = inactive_fields;
+    stats["total_fields"] = static_cast<Json::Int64>(total_fields);
+    stats["active_fields"] = static_cast<Json::Int64>(active_fields);
+    stats["inactive_fields"] = static_cast<Json::Int64>(inactive_fields);
     stats["total_energy_mev"] = total_energy;
     stats["average_energy_mev"] = average_energy;
     stats["peak_energy_mev"] = peak_energy;

--- a/src/cpp/physics.utilities.cpp
+++ b/src/cpp/physics.utilities.cpp
@@ -108,7 +108,8 @@ std::string energyFieldToJSON(const EnergyField& field) {
     json_field["memory_allocated"] = (field.memory_ptr != nullptr && field.memory_bytes > 0);
 
     if (field.memory_ptr && field.memory_bytes > 0) {
-        json_field["memory_address"] = reinterpret_cast<uintptr_t>(field.memory_ptr);
+        json_field["memory_address"] = static_cast<Json::UInt64>(
+            reinterpret_cast<uintptr_t>(field.memory_ptr));
 
         // Calculate memory entropy for monitoring
         double memory_entropy = calculateEntropy(field.memory_bytes, field.cpu_cycles);
@@ -155,8 +156,8 @@ std::string fissionEventToJSON(const TernaryFissionEvent& event) {
     auto serializeFragment = [](const FissionFragment& fragment) -> Json::Value {
         Json::Value json_fragment;
         json_fragment["mass"] = fragment.mass;
-        json_fragment["atomic_number"] = fragment.atomic_number;
-        json_fragment["mass_number"] = fragment.mass_number;
+        json_fragment["atomic_number"] = static_cast<Json::Int64>(fragment.atomic_number);
+        json_fragment["mass_number"] = static_cast<Json::Int64>(fragment.mass_number);
         json_fragment["kinetic_energy"] = fragment.kinetic_energy;
         json_fragment["binding_energy"] = fragment.binding_energy;
         json_fragment["excitation_energy"] = fragment.excitation_energy;
@@ -227,7 +228,7 @@ std::string formatHTTPResponse(const std::string& status, const std::string& mes
     Json::Value response;
     response["status"] = status;
     response["message"] = message;
-    response["http_status"] = http_status_code;
+    response["http_status"] = static_cast<Json::Int64>(http_status_code);
 
     if (!data.isNull() && !data.empty()) {
         response["data"] = data;

--- a/src/cpp/ternary.fission.simulation.engine.cpp
+++ b/src/cpp/ternary.fission.simulation.engine.cpp
@@ -200,7 +200,7 @@ Json::Value TernaryFissionSimulationEngine::simulateTernaryFissionEventAPI(const
         } catch (const std::exception& e) {
             Json::Value error;
             error["error"] = "Event simulation failed: " + std::string(e.what());
-            error["event_index"] = i;
+            error["event_index"] = static_cast<Json::Int64>(i);
             events_array.append(error);
         }
     }
@@ -210,7 +210,7 @@ Json::Value TernaryFissionSimulationEngine::simulateTernaryFissionEventAPI(const
 
     // Build response
     response["status"] = "success";
-    response["num_events"] = num_events;
+    response["num_events"] = static_cast<Json::Int64>(num_events);
     response["events"] = events_array;
     response["computation_time_microseconds"] = static_cast<Json::Int64>(duration.count());
     response["request_id"] = static_cast<Json::Int64>(api_request_counter_);
@@ -242,8 +242,9 @@ Json::Value TernaryFissionSimulationEngine::getSystemStatusAPI() const {
         status["total_computation_time_seconds"] = total_computation_time_seconds;
     }
 
-    status["worker_threads"] = num_worker_threads;
-    status["active_energy_fields"] = static_cast<int>(simulation_state.active_energy_fields.size());
+    status["worker_threads"] = static_cast<Json::Int64>(num_worker_threads);
+    status["active_energy_fields"] = static_cast<Json::Int64>(
+        simulation_state.active_energy_fields.size());
     status["energy_conservation_enabled"] = simulation_state.energy_conservation_enabled;
     status["momentum_conservation_enabled"] = simulation_state.momentum_conservation_enabled;
     status["target_events_per_second"] = target_events_per_second.load();
@@ -291,7 +292,8 @@ Json::Value TernaryFissionSimulationEngine::getEnergyFieldsAPI() const {
     }
 
     response["energy_fields"] = fields_array;
-    response["total_fields"] = static_cast<int>(simulation_state.active_energy_fields.size());
+    response["total_fields"] = static_cast<Json::Int64>(
+        simulation_state.active_energy_fields.size());
     response["status"] = "success";
 
     return response;
@@ -388,8 +390,10 @@ Json::Value TernaryFissionSimulationEngine::serializeFissionEventToJSON(const Te
     // Fragment data
     Json::Value heavy_fragment;
     heavy_fragment["mass"] = event.heavy_fragment.mass;
-    heavy_fragment["atomic_number"] = event.heavy_fragment.atomic_number;
-    heavy_fragment["mass_number"] = event.heavy_fragment.mass_number;
+    heavy_fragment["atomic_number"] = static_cast<Json::Int64>(
+        event.heavy_fragment.atomic_number);
+    heavy_fragment["mass_number"] = static_cast<Json::Int64>(
+        event.heavy_fragment.mass_number);
     heavy_fragment["kinetic_energy"] = event.heavy_fragment.kinetic_energy;
     heavy_fragment["momentum_x"] = event.heavy_fragment.momentum.x;
     heavy_fragment["momentum_y"] = event.heavy_fragment.momentum.y;
@@ -398,8 +402,10 @@ Json::Value TernaryFissionSimulationEngine::serializeFissionEventToJSON(const Te
 
     Json::Value light_fragment;
     light_fragment["mass"] = event.light_fragment.mass;
-    light_fragment["atomic_number"] = event.light_fragment.atomic_number;
-    light_fragment["mass_number"] = event.light_fragment.mass_number;
+    light_fragment["atomic_number"] = static_cast<Json::Int64>(
+        event.light_fragment.atomic_number);
+    light_fragment["mass_number"] = static_cast<Json::Int64>(
+        event.light_fragment.mass_number);
     light_fragment["kinetic_energy"] = event.light_fragment.kinetic_energy;
     light_fragment["momentum_x"] = event.light_fragment.momentum.x;
     light_fragment["momentum_y"] = event.light_fragment.momentum.y;
@@ -408,8 +414,10 @@ Json::Value TernaryFissionSimulationEngine::serializeFissionEventToJSON(const Te
 
     Json::Value alpha_particle;
     alpha_particle["mass"] = event.alpha_particle.mass;
-    alpha_particle["atomic_number"] = event.alpha_particle.atomic_number;
-    alpha_particle["mass_number"] = event.alpha_particle.mass_number;
+    alpha_particle["atomic_number"] = static_cast<Json::Int64>(
+        event.alpha_particle.atomic_number);
+    alpha_particle["mass_number"] = static_cast<Json::Int64>(
+        event.alpha_particle.mass_number);
     alpha_particle["kinetic_energy"] = event.alpha_particle.kinetic_energy;
     alpha_particle["momentum_x"] = event.alpha_particle.momentum.x;
     alpha_particle["momentum_y"] = event.alpha_particle.momentum.y;
@@ -463,7 +471,8 @@ Json::Value TernaryFissionSimulationEngine::serializeEnergyFieldToJSON(const Ene
     // Memory mapping info
     if (field.memory_ptr && field.memory_bytes > 0) {
         json_field["memory_allocated"] = true;
-        json_field["memory_address"] = reinterpret_cast<uintptr_t>(field.memory_ptr);
+        json_field["memory_address"] = static_cast<Json::UInt64>(
+            reinterpret_cast<uintptr_t>(field.memory_ptr));
     } else {
         json_field["memory_allocated"] = false;
     }

--- a/tests/field_statistics_test.cpp
+++ b/tests/field_statistics_test.cpp
@@ -26,9 +26,9 @@ Json::Value computeFieldStatistics(const std::map<std::string, std::unique_ptr<E
     double average_energy = total_fields > 0 ? total_energy / total_fields : 0.0;
 
     Json::Value stats;
-    stats["total_fields"] = total_fields;
-    stats["active_fields"] = active_fields;
-    stats["inactive_fields"] = inactive_fields;
+    stats["total_fields"] = static_cast<Json::Int64>(total_fields);
+    stats["active_fields"] = static_cast<Json::Int64>(active_fields);
+    stats["inactive_fields"] = static_cast<Json::Int64>(inactive_fields);
     stats["total_energy_mev"] = total_energy;
     stats["average_energy_mev"] = average_energy;
     stats["peak_energy_mev"] = peak_energy;


### PR DESCRIPTION
## Summary
- cast memory address to `Json::UInt64` when serializing energy fields
- add explicit `Json::Int64`/`UInt64` casts for fragment IDs and counts across engine and server
- ensure tests serialize integer statistics with `Json::Int64`

## Testing
- `make cpp-build` *(fails: json/json.h missing)*
- `make go-build` *(fails: json/json.h missing)*
- `make cpp-test` *(fails: no rule to make target 'cpp-test')*
- `make static-analysis` *(fails: no rule to make target 'static-analysis')*

------
https://chatgpt.com/codex/tasks/task_e_68976da5d270832bbd3b9e651302bf05