### PR TITLE
server: update energy field JSON

### DIFF
--- a/src/cpp/http.ternary.fission.server.cpp
+++ b/src/cpp/http.ternary.fission.server.cpp
@@ -1364,10 +1364,6 @@ void HTTPTernaryFissionServer::handleEnergyGeneration(const httplib::Request& re
         jf["energy_mev"] = field.energy_mev;
         jf["memory_bytes"] = static_cast<Json::UInt64>(field.memory_bytes);
         jf["cpu_cycles"] = static_cast<Json::UInt64>(field.cpu_cycles);
-        jf["entropy_factor"] = field.entropy_factor;
-        jf["dissipation_rate"] = field.dissipation_rate;
-        jf["stability_factor"] = field.stability_factor;
-        jf["interaction_strength"] = field.interaction_strength;
 
         auto time_since_epoch = field.creation_time.time_since_epoch();
         auto timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(time_since_epoch).count();


### PR DESCRIPTION
## Summary
- trim legacy energy field metrics from HTTP responses
- report only new metrics: energy_mev, memory_bytes, cpu_cycles, creation timestamp

## Testing
- `make cpp-build` *(fails: ‘struct std::atomic<double>’ has no member named ‘fetch_add’)*
- `make go-build`
- `make test`
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*

------
https://chatgpt.com/codex/tasks/task_e_68977102ecbc832ba2f65982682bf30a