### PR TITLE
physics: replace fetch_add with load-store

### DIFF
--- a/src/cpp/physics.utilities.cpp
+++ b/src/cpp/physics.utilities.cpp
@@ -130,7 +130,8 @@ std::string energyFieldToJSON(const EnergyField& field) {
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
 
     json_operations_counter_.fetch_add(1, std::memory_order_relaxed);
-    json_serialization_time_total_.fetch_add(duration.count() / 1e6, std::memory_order_relaxed);
+    double current = json_serialization_time_total_.load(std::memory_order_relaxed);
+    json_serialization_time_total_.store(current + duration.count() / 1e6, std::memory_order_relaxed);
 
     return json_string;
 }
@@ -212,7 +213,8 @@ std::string fissionEventToJSON(const TernaryFissionEvent& event) {
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
 
     json_operations_counter_.fetch_add(1, std::memory_order_relaxed);
-    json_serialization_time_total_.fetch_add(duration.count() / 1e6, std::memory_order_relaxed);
+    double current = json_serialization_time_total_.load(std::memory_order_relaxed);
+    json_serialization_time_total_.store(current + duration.count() / 1e6, std::memory_order_relaxed);
 
     return json_string;
 }


### PR DESCRIPTION
## Summary
- avoid atomic fetch_add in JSON timing metrics by manually loading and storing accumulated time

## Testing
- `make cpp-build` *(fails: error: 'const struct TernaryFission::TernaryFissionEvent' has no member named 'event_id', etc.)*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*

------
https://chatgpt.com/codex/tasks/task_e_689775cab950832bbaf9f7b8b5a4f71c