### PR TITLE
physics: replace nuclear fragment struct

### DIFF
--- a/include/physics.constants.definitions.h
+++ b/include/physics.constants.definitions.h
@@ -105,22 +105,33 @@ namespace TernaryFission {
     // =============================================================================
 
     /**
-     * We define the nuclear fragment structure to represent fission products
-     * Each fragment carries mass, energy, momentum, and decay properties
+     * Simple 3D vector structure for momentum and position
      */
-    struct NuclearFragment {
+    struct Vector3 {
+        double x, y, z;
+
+        Vector3() : x(0.0), y(0.0), z(0.0) {}
+    };
+
+    /**
+     * We define the fission fragment structure to represent decay products
+     * Each fragment carries mass, energy, momentum, position and decay properties
+     */
+    struct FissionFragment {
         double mass;              // Fragment mass in atomic mass units
-        double kinetic_energy;    // Kinetic energy in MeV
-        double momentum_x;        // Momentum components (MeV/c)
-        double momentum_y;
-        double momentum_z;
         int atomic_number;        // Number of protons
         int mass_number;          // Number of nucleons
+        double kinetic_energy;    // Kinetic energy in MeV
+        double binding_energy;    // Binding energy in MeV
+        double excitation_energy; // Excitation energy in MeV
+        Vector3 momentum;         // Momentum vector (MeV/c)
+        Vector3 position;         // Position vector (fm or arbitrary units)
         double half_life;         // Decay half-life in seconds
 
-        NuclearFragment() : mass(0.0), kinetic_energy(0.0),
-                           momentum_x(0.0), momentum_y(0.0), momentum_z(0.0),
-                           atomic_number(0), mass_number(0), half_life(0.0) {}
+        FissionFragment()
+            : mass(0.0), atomic_number(0), mass_number(0),
+              kinetic_energy(0.0), binding_energy(0.0), excitation_energy(0.0),
+              momentum(), position(), half_life(0.0) {}
     };
 
     /**
@@ -131,9 +142,9 @@ namespace TernaryFission {
         std::uint64_t event_id;            // Unique event identifier
         std::uint64_t energy_field_id;     // Associated energy field identifier
 
-        NuclearFragment light_fragment;    // Lighter fission fragment
-        NuclearFragment heavy_fragment;    // Heavier fission fragment
-        NuclearFragment alpha_particle;    // Third particle (usually alpha)
+        FissionFragment light_fragment;    // Lighter fission fragment
+        FissionFragment heavy_fragment;    // Heavier fission fragment
+        FissionFragment alpha_particle;    // Third particle (usually alpha)
 
         double total_kinetic_energy;       // Total KE released (MeV)
         double q_value;                    // Q-value of reaction (MeV)
@@ -249,8 +260,8 @@ namespace TernaryFission {
     // =============================================================================
 
     // We declare utility functions for physics calculations
-    double calculateTernaryFissionQ(double parent_mass, const NuclearFragment& frag1,
-                                   const NuclearFragment& frag2, const NuclearFragment& frag3);
+    double calculateTernaryFissionQ(double parent_mass, const FissionFragment& frag1,
+                                   const FissionFragment& frag2, const FissionFragment& frag3);
 
     bool verifyMomentumConservation(const TernaryFissionEvent& event, double tolerance = 1e-6);
     bool verifyEnergyConservation(const TernaryFissionEvent& event, double tolerance = 1e-3);

--- a/src/cpp/http.ternary.fission.server.cpp
+++ b/src/cpp/http.ternary.fission.server.cpp
@@ -1274,13 +1274,25 @@ void HTTPTernaryFissionServer::handleFissionCalculation(const httplib::Request& 
         response["q_value"] = event.q_value;
         response["total_kinetic_energy"] = event.total_kinetic_energy;
 
-        auto serializeFragment = [](const NuclearFragment& frag) {
+        auto serializeFragment = [](const FissionFragment& frag) {
             Json::Value jf;
             jf["mass"] = frag.mass;
+            jf["atomic_number"] = static_cast<Json::Int64>(frag.atomic_number);
+            jf["mass_number"] = static_cast<Json::Int64>(frag.mass_number);
             jf["kinetic_energy"] = frag.kinetic_energy;
-            jf["momentum_x"] = frag.momentum_x;
-            jf["momentum_y"] = frag.momentum_y;
-            jf["momentum_z"] = frag.momentum_z;
+            jf["binding_energy"] = frag.binding_energy;
+            jf["excitation_energy"] = frag.excitation_energy;
+            jf["half_life"] = frag.half_life;
+            Json::Value momentum;
+            momentum["x"] = frag.momentum.x;
+            momentum["y"] = frag.momentum.y;
+            momentum["z"] = frag.momentum.z;
+            jf["momentum"] = momentum;
+            Json::Value position;
+            position["x"] = frag.position.x;
+            position["y"] = frag.position.y;
+            position["z"] = frag.position.z;
+            jf["position"] = position;
             return jf;
         };
 
@@ -1307,12 +1319,22 @@ void HTTPTernaryFissionServer::handleConservationLaws(const httplib::Request& re
         TernaryFissionEvent event;
         event.q_value = body.get("q_value", 0.0).asDouble();
 
-        auto parseFragment = [](const Json::Value& jf, NuclearFragment& frag) {
-            frag.kinetic_energy = jf.get("kinetic_energy", 0.0).asDouble();
-            frag.momentum_x = jf.get("momentum_x", 0.0).asDouble();
-            frag.momentum_y = jf.get("momentum_y", 0.0).asDouble();
-            frag.momentum_z = jf.get("momentum_z", 0.0).asDouble();
+        auto parseFragment = [](const Json::Value& jf, FissionFragment& frag) {
             frag.mass = jf.get("mass", 0.0).asDouble();
+            frag.atomic_number = jf.get("atomic_number", 0).asInt();
+            frag.mass_number = jf.get("mass_number", 0).asInt();
+            frag.kinetic_energy = jf.get("kinetic_energy", 0.0).asDouble();
+            frag.binding_energy = jf.get("binding_energy", 0.0).asDouble();
+            frag.excitation_energy = jf.get("excitation_energy", 0.0).asDouble();
+            frag.half_life = jf.get("half_life", 0.0).asDouble();
+            const Json::Value& momentum = jf["momentum"];
+            frag.momentum.x = momentum.get("x", 0.0).asDouble();
+            frag.momentum.y = momentum.get("y", 0.0).asDouble();
+            frag.momentum.z = momentum.get("z", 0.0).asDouble();
+            const Json::Value& position = jf["position"];
+            frag.position.x = position.get("x", 0.0).asDouble();
+            frag.position.y = position.get("y", 0.0).asDouble();
+            frag.position.z = position.get("z", 0.0).asDouble();
         };
 
         parseFragment(body["heavy_fragment"], event.heavy_fragment);

--- a/src/cpp/ternary.fission.simulation.engine.cpp
+++ b/src/cpp/ternary.fission.simulation.engine.cpp
@@ -395,9 +395,19 @@ Json::Value TernaryFissionSimulationEngine::serializeFissionEventToJSON(const Te
     heavy_fragment["mass_number"] = static_cast<Json::Int64>(
         event.heavy_fragment.mass_number);
     heavy_fragment["kinetic_energy"] = event.heavy_fragment.kinetic_energy;
-    heavy_fragment["momentum_x"] = event.heavy_fragment.momentum.x;
-    heavy_fragment["momentum_y"] = event.heavy_fragment.momentum.y;
-    heavy_fragment["momentum_z"] = event.heavy_fragment.momentum.z;
+    heavy_fragment["binding_energy"] = event.heavy_fragment.binding_energy;
+    heavy_fragment["excitation_energy"] = event.heavy_fragment.excitation_energy;
+    heavy_fragment["half_life"] = event.heavy_fragment.half_life;
+    Json::Value heavy_momentum;
+    heavy_momentum["x"] = event.heavy_fragment.momentum.x;
+    heavy_momentum["y"] = event.heavy_fragment.momentum.y;
+    heavy_momentum["z"] = event.heavy_fragment.momentum.z;
+    heavy_fragment["momentum"] = heavy_momentum;
+    Json::Value heavy_position;
+    heavy_position["x"] = event.heavy_fragment.position.x;
+    heavy_position["y"] = event.heavy_fragment.position.y;
+    heavy_position["z"] = event.heavy_fragment.position.z;
+    heavy_fragment["position"] = heavy_position;
     json_event["heavy_fragment"] = heavy_fragment;
 
     Json::Value light_fragment;
@@ -407,9 +417,19 @@ Json::Value TernaryFissionSimulationEngine::serializeFissionEventToJSON(const Te
     light_fragment["mass_number"] = static_cast<Json::Int64>(
         event.light_fragment.mass_number);
     light_fragment["kinetic_energy"] = event.light_fragment.kinetic_energy;
-    light_fragment["momentum_x"] = event.light_fragment.momentum.x;
-    light_fragment["momentum_y"] = event.light_fragment.momentum.y;
-    light_fragment["momentum_z"] = event.light_fragment.momentum.z;
+    light_fragment["binding_energy"] = event.light_fragment.binding_energy;
+    light_fragment["excitation_energy"] = event.light_fragment.excitation_energy;
+    light_fragment["half_life"] = event.light_fragment.half_life;
+    Json::Value light_momentum;
+    light_momentum["x"] = event.light_fragment.momentum.x;
+    light_momentum["y"] = event.light_fragment.momentum.y;
+    light_momentum["z"] = event.light_fragment.momentum.z;
+    light_fragment["momentum"] = light_momentum;
+    Json::Value light_position;
+    light_position["x"] = event.light_fragment.position.x;
+    light_position["y"] = event.light_fragment.position.y;
+    light_position["z"] = event.light_fragment.position.z;
+    light_fragment["position"] = light_position;
     json_event["light_fragment"] = light_fragment;
 
     Json::Value alpha_particle;
@@ -419,9 +439,19 @@ Json::Value TernaryFissionSimulationEngine::serializeFissionEventToJSON(const Te
     alpha_particle["mass_number"] = static_cast<Json::Int64>(
         event.alpha_particle.mass_number);
     alpha_particle["kinetic_energy"] = event.alpha_particle.kinetic_energy;
-    alpha_particle["momentum_x"] = event.alpha_particle.momentum.x;
-    alpha_particle["momentum_y"] = event.alpha_particle.momentum.y;
-    alpha_particle["momentum_z"] = event.alpha_particle.momentum.z;
+    alpha_particle["binding_energy"] = event.alpha_particle.binding_energy;
+    alpha_particle["excitation_energy"] = event.alpha_particle.excitation_energy;
+    alpha_particle["half_life"] = event.alpha_particle.half_life;
+    Json::Value alpha_momentum;
+    alpha_momentum["x"] = event.alpha_particle.momentum.x;
+    alpha_momentum["y"] = event.alpha_particle.momentum.y;
+    alpha_momentum["z"] = event.alpha_particle.momentum.z;
+    alpha_particle["momentum"] = alpha_momentum;
+    Json::Value alpha_position;
+    alpha_position["x"] = event.alpha_particle.position.x;
+    alpha_position["y"] = event.alpha_particle.position.y;
+    alpha_position["z"] = event.alpha_particle.position.z;
+    alpha_particle["position"] = alpha_position;
     json_event["alpha_particle"] = alpha_particle;
 
     // Energy data


### PR DESCRIPTION
## Summary
- introduce `Vector3` and `FissionFragment` with momentum and position vectors
- refactor fission event and HTTP/engine serialization to use `FissionFragment`

## Testing
- `make cpp-build` *(fails: encryptMemoryPattern not declared)*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*

------
https://chatgpt.com/codex/tasks/task_e_689778af2e38832ba7af4dec29a9adde