### PR TITLE
physics: expand performance metrics

### DIFF
--- a/include/physics.utilities.h
+++ b/include/physics.utilities.h
@@ -206,8 +206,11 @@ struct PerformanceMetrics {
     double average_event_processing_time_ms;
     double memory_usage_mb;
     double cpu_utilization_percent;
+    double cpu_time_seconds;
     std::uint64_t total_energy_fields_active;
     std::uint64_t total_memory_pool_allocated;
+    std::uint64_t page_faults;
+    std::uint64_t context_switches;
     std::chrono::steady_clock::time_point measurement_time;
 };
 

--- a/src/cpp/physics.utilities.cpp
+++ b/src/cpp/physics.utilities.cpp
@@ -680,6 +680,11 @@ PerformanceMetrics getCurrentPerformanceMetrics() {
     double cpu_time = usage.ru_utime.tv_sec + usage.ru_utime.tv_usec / 1e6 +
                       usage.ru_stime.tv_sec + usage.ru_stime.tv_usec / 1e6;
     metrics.cpu_utilization_percent = cpu_time * 100.0;
+    metrics.cpu_time_seconds = cpu_time;
+
+    // Page faults and context switches
+    metrics.page_faults = usage.ru_minflt + usage.ru_majflt;
+    metrics.context_switches = usage.ru_nvcsw + usage.ru_nivcsw;
 
     // Placeholder metrics not yet collected
     metrics.events_per_second = 0.0;


### PR DESCRIPTION
## Summary
- extend `PerformanceMetrics` with CPU time, page fault, and context switch counters
- report new metrics using `getrusage`

## Testing
- `make cpp-build` *(fails: no match for operator* in ternary.fission.simulation.engine.cpp)*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*


------
https://chatgpt.com/codex/tasks/task_e_6897def58da8832bb00487a3e8065f34