### PR TITLE
engine: reorder initializer list

### DIFF
--- a/src/cpp/ternary.fission.simulation.engine.cpp
+++ b/src/cpp/ternary.fission.simulation.engine.cpp
@@ -82,10 +82,10 @@ TernaryFissionSimulationEngine::TernaryFissionSimulationEngine(double default_ma
       num_worker_threads(threads),
       total_events_simulated(0),
       total_energy_fields_created(0),
-      total_computation_time_seconds(0.0),
       shutdown_requested(false),
       continuous_mode_active(false),
       target_events_per_second(10.0),
+      total_computation_time_seconds(0.0),
       api_request_counter_(0),
       json_serialization_enabled_(true) {
 


### PR DESCRIPTION
## Summary
- Reorder `TernaryFissionSimulationEngine` constructor initializer list to align with member declaration order

## Testing
- `make cpp-build` *(fails: operator overload and missing functions)*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target)*
- `make static-analysis` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_6897e25d3708832b8ee1340db8698ef3