### PR TITLE
simulation: add energy field dissipation helper

### DIFF
--- a/include/physics.constants.definitions.h
+++ b/include/physics.constants.definitions.h
@@ -268,7 +268,7 @@ namespace TernaryFission {
     bool verifyEnergyConservation(const TernaryFissionEvent& event, double tolerance = 1e-3);
 
     void allocateEnergyField(EnergyField& field, double energy_mev);
-    void dissipateEnergyField(EnergyField& field, int encryption_rounds);
+    void dissipateEnergyField(EnergyField& field);
 
     // We provide random number generation for physics simulation
     double generateGaussianRandom(SimulationState& state, double mean, double sigma);

--- a/include/physics.utilities.h
+++ b/include/physics.utilities.h
@@ -120,9 +120,8 @@ void allocateEnergyField(EnergyField& field, double energy_mev);
  * We model energy loss through computational work
  *
  * @param field: Energy field to dissipate
- * @param rounds: Number of encryption rounds to perform
  */
-void dissipateEnergyField(EnergyField& field, int rounds);
+void dissipateEnergyField(EnergyField& field);
 
 /*
  * Generate random momentum for a fission fragment

--- a/src/cpp/ternary.fission.simulation.engine.cpp
+++ b/src/cpp/ternary.fission.simulation.engine.cpp
@@ -376,6 +376,19 @@ Json::Value TernaryFissionSimulationEngine::createEnergyFieldAPI(const Json::Val
 }
 
 /*
+ * Dissipate energy from an existing field
+ * We apply physics utility dissipation for the specified rounds
+ */
+void TernaryFissionSimulationEngine::dissipateEnergyField(EnergyField& field, int rounds) {
+    for (int i = 0; i < rounds; ++i) {
+        ::TernaryFission::dissipateEnergyField(field);
+        if (field.energy_mev <= 0.0) {
+            break;
+        }
+    }
+}
+
+/*
  * Serialize fission event to JSON format
  * We convert physics data structures to JSON for HTTP API
  */
@@ -821,7 +834,7 @@ void TernaryFissionSimulationEngine::updateEnergyFields() {
     auto it = simulation_state.active_energy_fields.begin();
     while (it != simulation_state.active_energy_fields.end()) {
         // Apply dissipation using physics utilities
-        ::TernaryFission::dissipateEnergyField(*it);
+        dissipateEnergyField(*it, 1);
 
         // Remove fields with very low energy
         if (it->energy_mev < 0.001) {


### PR DESCRIPTION
## Summary
- add simulation engine helper to dissipate energy fields
- route updateEnergyFields through the new helper
- align physics utility headers for single-argument dissipateEnergyField

## Testing
- `make cpp-build` *(fails: fatal error: ternary.fission.simulation.engine.h: No such file or directory)*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*

------
https://chatgpt.com/codex/tasks/task_e_6897f82d7614832b86b189e737fd3c5d