### PR TITLE
engine: silence unused parameters

### DIFF
--- a/src/cpp/ternary.fission.simulation.engine.cpp
+++ b/src/cpp/ternary.fission.simulation.engine.cpp
@@ -763,6 +763,8 @@ void TernaryFissionSimulationEngine::processFissionEvent(const TernaryFissionEve
  * We process events from the queue in parallel
  */
 void TernaryFissionSimulationEngine::workerThreadFunction(int thread_id) {
+    (void)thread_id;
+
     while (!shutdown_requested.load()) {
         std::unique_lock<std::mutex> lock(queue_mutex);
 
@@ -850,6 +852,8 @@ void TernaryFissionSimulationEngine::updateEnergyFields() {
  * We record events for analysis
  */
 void TernaryFissionSimulationEngine::logFissionEvent(const TernaryFissionEvent& event) {
+    (void)event;
+
     // Event logging implementation would write to log files
     // For now, we just track in memory
 }


### PR DESCRIPTION
## Summary
- avoid unused parameter warnings for worker threads
- suppress unused event variable in fission event logging

## Testing
- `make cpp-build` *(fails: fatal error: ternary.fission.simulation.engine.h: No such file or directory)*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*


------
https://chatgpt.com/codex/tasks/task_e_6897faa80ba8832bb7849fd99bba98ae