### PR TITLE
simulation: add energy field wrapper

### DIFF
--- a/src/cpp/ternary.fission.simulation.engine.cpp
+++ b/src/cpp/ternary.fission.simulation.engine.cpp
@@ -63,6 +63,14 @@
 namespace TernaryFission {
 
 /*
+ * Create an energy field with specified energy
+ * We allocate computational resources to represent energy
+ */
+EnergyField TernaryFissionSimulationEngine::createEnergyField(double energy_mev) {
+    return ::TernaryFission::createEnergyField(energy_mev);
+}
+
+/*
  * Default constructor implementation
  * We use standard U-235 fission parameters
  */
@@ -337,14 +345,6 @@ Json::Value TernaryFissionSimulationEngine::stopContinuousSimulationAPI() {
     response["simulation_running"] = false;
 
     return response;
-}
-
-/*
- * Create an energy field with specified energy
- * We allocate computational resources to represent energy
- */
-EnergyField TernaryFissionSimulationEngine::createEnergyField(double energy_mev) {
-    return TernaryFission::createEnergyField(energy_mev);
 }
 
 /*


### PR DESCRIPTION
## Summary
- add EnergyField wrapper delegating to global utility

## Testing
- `make cpp-build` *(fails: cannot convert `PhysicsConfiguration*` to `EnergyFieldConfig*` and missing function-definition errors)*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*

------
https://chatgpt.com/codex/tasks/task_e_6898188c03ec832ba90e71fda19b9023