### PR TITLE
Refactor total energy calculation signature

### DIFF
--- a/include/physics.utilities.h
+++ b/include/physics.utilities.h
@@ -326,10 +326,10 @@ bool validateEnergyField(const EnergyField& field);
  * Calculate total system energy
  * We sum all energy in active fields
  *
- * @param fields: Vector of energy field pointers
- * @return: Total energy in MeV
- */
-double calculateTotalSystemEnergy(const std::vector<EnergyField*>& fields);
+ * @param fields: Vector of energy fields
+* @return: Total energy in MeV
+*/
+double calculateTotalSystemEnergy(const std::vector<EnergyField>& fields);
 
 /*
  * Physics calculation helpers

--- a/src/cpp/physics.utilities.cpp
+++ b/src/cpp/physics.utilities.cpp
@@ -733,12 +733,12 @@ bool validateEnergyField(const EnergyField& field) {
  * Calculate total system energy
  * We sum all energy in active fields
  */
-double calculateTotalSystemEnergy(const std::vector<EnergyField*>& fields) {
+double calculateTotalSystemEnergy(const std::vector<EnergyField>& fields) {
     double total_energy = 0.0;
 
-    for (const auto* field : fields) {
-        if (field && validateEnergyField(*field)) {
-            total_energy += field->energy_mev;
+    for (const auto& field : fields) {
+        if (validateEnergyField(field)) {
+            total_energy += field.energy_mev;
         }
     }
 


### PR DESCRIPTION
## Summary
- Accept vectors of `EnergyField` values in `calculateTotalSystemEnergy`.
- Iterate over energy field values and access `energy_mev` directly.

## Testing
- `make cpp-build` *(fails: cannot convert const TernaryFission::PhysicsConfiguration*)
- `make go-build`
- `make cpp-test` *(fails: No rule to make target `cpp-test`)*
- `make static-analysis` *(fails: No rule to make target `static-analysis`)*

------
https://chatgpt.com/codex/tasks/task_e_68981aaee244832b8882d087953970fe