### PR TITLE
config: add web root directory

### DIFF
--- a/configs/daemon.config
+++ b/configs/daemon.config
@@ -80,8 +80,11 @@ cors_origins = *
 # Range: 1024-1073741824 (1KB-1GB), recommended: 10MB for API
 request_size_limit = 10485760
 
+# We specify filesystem path for static assets
+web_root = web
+
 # =============================================================================
-# DAEMON CONFIGURATION - Process Management Settings  
+# DAEMON CONFIGURATION - Process Management Settings
 # =============================================================================
 
 # We enable daemon mode for background operation

--- a/configs/ternary_fission.conf
+++ b/configs/ternary_fission.conf
@@ -110,6 +110,9 @@ api_timeout=30
 max_request_size=10485760
 max_concurrent_connections=1000
 
+# Filesystem path for static assets
+web_root=web
+
 # WebSocket configuration
 websocket_enabled=true
 websocket_buffer_size=4096

--- a/include/config.ternary.fission.server.h
+++ b/include/config.ternary.fission.server.h
@@ -64,7 +64,8 @@ struct NetworkConfiguration {
     bool enable_cors = true;                    // Cross-Origin Resource Sharing
     std::vector<std::string> cors_origins;      // Allowed CORS origins
     int request_size_limit = 10485760;          // Maximum request size (10MB)
-    
+    std::string web_root;                       // Filesystem path for static assets
+
     NetworkConfiguration() {
         cors_origins = {"*"};  // Default to allow all origins
     }

--- a/src/cpp/config.ternary.fission.server.cpp
+++ b/src/cpp/config.ternary.fission.server.cpp
@@ -234,7 +234,8 @@ bool ConfigurationManager::parseNetworkConfiguration() {
     network_config_.connection_timeout = getConfigInt("connection_timeout", 30);
     network_config_.enable_cors = getConfigBool("enable_cors", true);
     network_config_.request_size_limit = getConfigInt("request_size_limit", 10485760);
-    
+    network_config_.web_root = getConfigValue("web_root", "");
+
     // We parse CORS origins list
     std::string cors_origins_str = getConfigValue("cors_origins", "*");
     if (cors_origins_str != "*") {
@@ -357,7 +358,13 @@ bool ConfigurationManager::validateNetworkConfiguration() {
         addValidationError("Invalid request_size_limit: " + std::to_string(network_config_.request_size_limit));
         valid = false;
     }
-    
+
+    // We validate web root directory
+    if (!ConfigurationUtils::validateDirectoryPath(network_config_.web_root, false)) {
+        addValidationError("Invalid web_root: " + network_config_.web_root);
+        valid = false;
+    }
+
     return valid;
 }
 


### PR DESCRIPTION
## Summary
- extend network configuration with `web_root` for static asset directory
- parse and validate `web_root` in config manager
- expose `web_root` in sample configuration files

## Testing
- `make cpp-build`
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*

------
https://chatgpt.com/codex/tasks/task_e_6898246dd444832b81e1c689b58442e5