### PR TITLE
api: proxy energy field requests to reactor

### DIFF
--- a/configs/ternary_fission.conf
+++ b/configs/ternary_fission.conf
@@ -109,6 +109,7 @@ api_host=0.0.0.0
 api_timeout=30
 max_request_size=10485760
 max_concurrent_connections=1000
+reactor_base_url=http://localhost:8333
 
 # Filesystem path for static assets
 web_root=web


### PR DESCRIPTION
## Summary
- add `ReactorBaseURL` configuration and HTTP client for reactor communication
- proxy energy field CRUD and status requests to reactor endpoints
- document reactor URL in default configuration

## Testing
- `make cpp-build` *(fails: json/json.h: No such file or directory)*
- `make go-build`


------
https://chatgpt.com/codex/tasks/task_e_689833577598832b94a3765290126571