### PR TITLE
monitoring: poll reactor status metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,8 @@ curl -X POST http://localhost:8080/api/v1/energy-fields \
 ```bash
 # Available at http://localhost:8080/api/v1/metrics
 ternary_fission_api_requests_total
-ternary_fission_active_energy_fields
-ternary_fission_total_energy_mev
+reactor_active_fields
+reactor_total_energy_mev
 ternary_fission_api_response_time_seconds
 ```
 

--- a/configs/ternary_fission.conf
+++ b/configs/ternary_fission.conf
@@ -112,6 +112,9 @@ max_concurrent_connections=1000
 # Base URL for the backing reactor service
 reactor_base_url=http://127.0.0.1:8333
 
+# Interval in seconds for polling reactor status
+status_poll_interval=15
+
 # Filesystem path for static assets
 web_root=web
 


### PR DESCRIPTION
## Summary
- add `status_poll_interval` config option
- poll reactor `/api/v1/status` to update `reactor_active_fields` and `reactor_total_energy_mev`
- document new metrics in README and sample config

## Testing
- `make cpp-build` *(fails: json/json.h: No such file or directory)*
- `make go-build`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6898a82c5954832baf77629bf8616045