### PR TITLE
go: add API integration tests and go-test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ TEST_BINARIES := $(FD_COUNT_TEST) $(SYSTEM_METRICS_TEST) $(INTEGRATION_TEST)
 # =============================================================================
 # TARGETS
 # =============================================================================
-.PHONY: all cpp-build help clean test qa install docker release dist deb test-fd test-metrics test-integration
+.PHONY: all cpp-build go-build go-test help clean test qa install docker release dist deb test-fd test-metrics test-integration
 
 all: info $(CPP_MAIN) go-build
 
@@ -229,6 +229,13 @@ cpp-build: $(CPP_MAIN)
 go-build:
 	@cd $(GO_SRC_DIR) && $(GO) build -ldflags "-X main.Version=$(VERSION) -X main.BuildDate=$(BUILD_DATE) -X main.GitCommit=$(GIT_COMMIT)" -o ../../$(GO_BINARY)
 	@echo "✓ Go binary built: $(GO_BINARY)"
+
+# =============================================================================
+# GO TEST
+# =============================================================================
+go-test:
+	@cd $(GO_SRC_DIR) && $(GO) test ./...
+	@echo "✓ Go tests passed"
 
 # =============================================================================
 # TEST AND QA

--- a/src/go/api_integration_test.go
+++ b/src/go/api_integration_test.go
@@ -1,0 +1,110 @@
+/*
+ * File: src/go/api_integration_test.go
+ * Author: OpenAI
+ * Date: 2025-02-15
+ * Title: API integration tests for reactor forwarding
+ * Purpose: Ensure API server forwards requests to reactor stub and parses responses
+ * Reason: Provides regression coverage for energy field and status endpoints
+ *
+ * Change Log:
+ * 2025-02-15: Initial tests for energy field forwarding and status parsing
+ */
+
+package main
+
+import (
+    "encoding/json"
+    "io"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+// TestListEnergyFieldsForwards verifies that the API forwards energy field requests to the reactor.
+func TestListEnergyFieldsForwards(t *testing.T) {
+    called := false
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if r.URL.Path != "/api/v1/energy-fields" {
+            t.Fatalf("unexpected path: %s", r.URL.Path)
+        }
+        called = true
+        w.Header().Set("Content-Type", "application/json")
+        w.Write([]byte(`[{"id":"abc"}]`))
+    }))
+    defer stub.Close()
+
+    cfg := &Config{
+        ReactorBaseURL:    stub.URL,
+        APITimeout:        5,
+        PrometheusEnabled: false,
+    }
+
+    api := NewTernaryFissionAPIServer(cfg)
+    server := httptest.NewServer(api.router)
+    defer server.Close()
+
+    resp, err := http.Get(server.URL + "/api/v1/energy-fields")
+    if err != nil {
+        t.Fatalf("request failed: %v", err)
+    }
+    defer resp.Body.Close()
+
+    if !called {
+        t.Fatalf("stub not called")
+    }
+
+    body, _ := io.ReadAll(resp.Body)
+    if string(body) != `[{"id":"abc"}]` {
+        t.Fatalf("unexpected body: %s", string(body))
+    }
+}
+
+// TestGetSystemStatusParsesResponse ensures status endpoint parses reactor response correctly.
+func TestGetSystemStatusParsesResponse(t *testing.T) {
+    expected := SystemStatusResponse{
+        UptimeSeconds:        10,
+        TotalFissionEvents:   3,
+        TotalEnergySimulated: 4.5,
+        ActiveEnergyFields:   1,
+        PeakMemoryUsage:      0,
+        AverageCalcTime:      0,
+        TotalCalculations:    0,
+        SimulationRunning:    true,
+        CPUUsagePercent:      0.7,
+        MemoryUsagePercent:   0.2,
+    }
+
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if r.URL.Path != "/api/v1/status" {
+            t.Fatalf("unexpected path: %s", r.URL.Path)
+        }
+        w.Header().Set("Content-Type", "application/json")
+        json.NewEncoder(w).Encode(expected)
+    }))
+    defer stub.Close()
+
+    cfg := &Config{
+        ReactorBaseURL:    stub.URL,
+        APITimeout:        5,
+        PrometheusEnabled: false,
+    }
+
+    api := NewTernaryFissionAPIServer(cfg)
+    server := httptest.NewServer(api.router)
+    defer server.Close()
+
+    resp, err := http.Get(server.URL + "/api/v1/status")
+    if err != nil {
+        t.Fatalf("request failed: %v", err)
+    }
+    defer resp.Body.Close()
+
+    var got SystemStatusResponse
+    if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+        t.Fatalf("decode failed: %v", err)
+    }
+
+    if got != expected {
+        t.Fatalf("unexpected status: %+v", got)
+    }
+}


### PR DESCRIPTION
## Summary
- add HTTP integration tests covering energy field forwarding and status parsing
- introduce `go-test` Makefile target for running Go tests

## Testing
- `make cpp-build`
- `make go-build`
- `make go-test`


------
https://chatgpt.com/codex/tasks/task_e_6898ab1577ec832b9b54a3631ca26b80