### PR TITLE
web: add atomic dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ make static-analysis # run static analysis
 # configs/ternary_fission.conf
 parent_mass=235.0
 excitation_energy=6.5
-web_root=web
+web_root=webroot
 media_streaming_enabled=false
 ```
 
@@ -86,6 +86,16 @@ open http://localhost:8080
 curl http://localhost:8333/index.html      # Fetch static test page
 curl http://localhost:8333/stream          # Stream media content
 ```
+
+### Web Dashboard Structure
+- **Atoms** (`web/atoms`): buttons, inputs, and shared styles
+- **Molecules** (`web/molecules`): login form and status cards
+- **Organisms** (`web/organisms`): navigation bar and metrics panel
+- **Templates** (`web/templates`): layout shells
+- **Pages** (`web/pages`): entry points `index.html` and `login.html`
+
+Set `web_root=webroot` so the C++ HTTP server serves the `webroot/` directory.
+Open `http://localhost:8333/login.html` to authenticate and reach the dashboard. The metrics panel polls `/api/v1/metrics` and management controls send commands such as `POST /api/v1/control/shutdown`.
 
 ### ⚠️ In Testing/Validation Phase
 - **WebSocket Monitoring**: Basic implementation, real-time validation ongoing

--- a/web/atoms/button.js
+++ b/web/atoms/button.js
@@ -1,0 +1,17 @@
+/*
+ * File: web/atoms/button.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Button atom component
+ * Purpose: Provides reusable button element for web dashboard
+ * Reason: Implements atomic design principles for UI elements
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+export function createButton(text, type = "button") {
+    const button = document.createElement("button");
+    button.type = type;
+    button.textContent = text;
+    return button;
+}

--- a/web/atoms/input.js
+++ b/web/atoms/input.js
@@ -1,0 +1,18 @@
+/*
+ * File: web/atoms/input.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Input atom component
+ * Purpose: Provides reusable input element for web dashboard
+ * Reason: Implements atomic design principles for UI elements
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+export function createInput(id, type = "text", placeholder = "") {
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = type;
+    input.placeholder = placeholder;
+    return input;
+}

--- a/web/atoms/styles.css
+++ b/web/atoms/styles.css
@@ -1,0 +1,43 @@
+/*
+ * File: web/atoms/styles.css
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Shared atomic styles
+ * Purpose: Defines CSS variables and base styles for atomic components
+ * Reason: Promotes DRY principles across UI elements
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+:root {
+    --primary-color: #4CAF50;
+    --secondary-color: #ffffff;
+    --font-family: Arial, sans-serif;
+}
+
+button {
+    background-color: var(--primary-color);
+    color: var(--secondary-color);
+    padding: 0.5rem 1rem;
+    border: none;
+    cursor: pointer;
+}
+
+input {
+    padding: 0.5rem;
+    margin: 0.25rem 0;
+    font-family: var(--font-family);
+}
+
+nav {
+    background-color: var(--primary-color);
+    color: var(--secondary-color);
+    padding: 0.5rem;
+}
+
+.status-card {
+    border: 1px solid var(--primary-color);
+    margin: 0.5rem;
+    padding: 0.5rem;
+    font-family: var(--font-family);
+}

--- a/web/molecules/loginForm.js
+++ b/web/molecules/loginForm.js
@@ -1,0 +1,42 @@
+/*
+ * File: web/molecules/loginForm.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Login form molecule
+ * Purpose: Combines input and button atoms into a login form
+ * Reason: Implements authentication workflow using atomic components
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { createInput } from "/atoms/input.js";
+import { createButton } from "/atoms/button.js";
+
+export function createLoginForm(onSuccess) {
+    const form = document.createElement("form");
+    const user = createInput("username", "text", "Username");
+    const pass = createInput("password", "password", "Password");
+    const submit = createButton("Login", "submit");
+
+    form.appendChild(user);
+    form.appendChild(pass);
+    form.appendChild(submit);
+
+    form.addEventListener("submit", async (e) => {
+        e.preventDefault();
+        const response = await fetch("/api/v1/login", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({username: user.value, password: pass.value})
+        });
+        if (response.ok) {
+            const data = await response.json();
+            sessionStorage.setItem("token", data.token || "");
+            onSuccess();
+        } else {
+            alert("Login failed");
+        }
+    });
+
+    return form;
+}

--- a/web/molecules/statusCard.js
+++ b/web/molecules/statusCard.js
@@ -1,0 +1,22 @@
+/*
+ * File: web/molecules/statusCard.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Status card molecule
+ * Purpose: Displays labeled value for metrics
+ * Reason: Reusable component for monitoring data
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+export function createStatusCard(label, initial = "...") {
+    const card = document.createElement("div");
+    card.className = "status-card";
+    const title = document.createElement("h3");
+    title.textContent = label;
+    const value = document.createElement("p");
+    value.textContent = initial;
+    card.appendChild(title);
+    card.appendChild(value);
+    return {card, update: (val) => {value.textContent = val;}};
+}

--- a/web/organisms/metricsPanel.js
+++ b/web/organisms/metricsPanel.js
@@ -1,0 +1,37 @@
+/*
+ * File: web/organisms/metricsPanel.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Metrics panel organism
+ * Purpose: Displays real-time metrics with periodic fetching
+ * Reason: Provides monitoring interface for reactor data
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { createStatusCard } from "/molecules/statusCard.js";
+
+export function createMetricsPanel() {
+    const panel = document.createElement("div");
+    const power = createStatusCard("Power", "0 MW");
+    const temp = createStatusCard("Temperature", "0 C");
+    panel.appendChild(power.card);
+    panel.appendChild(temp.card);
+
+    async function updateMetrics() {
+        const response = await fetch("/api/v1/metrics");
+        if (response.ok) {
+            const data = await response.json();
+            if (data.power !== undefined) {
+                power.update(`${data.power} MW`);
+            }
+            if (data.temperature !== undefined) {
+                temp.update(`${data.temperature} C`);
+            }
+        }
+    }
+
+    updateMetrics();
+    setInterval(updateMetrics, 5000);
+    return panel;
+}

--- a/web/organisms/navBar.js
+++ b/web/organisms/navBar.js
@@ -1,0 +1,35 @@
+/*
+ * File: web/organisms/navBar.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Navigation bar organism
+ * Purpose: Provides application navigation and management controls
+ * Reason: Centralized user actions including logout and shutdown
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { createButton } from "/atoms/button.js";
+
+export function createNavBar() {
+    const nav = document.createElement("nav");
+    const home = document.createElement("a");
+    home.href = "/index.html";
+    home.textContent = "Dashboard";
+
+    const shutdownBtn = createButton("Shutdown");
+    shutdownBtn.addEventListener("click", async () => {
+        await fetch("/api/v1/control/shutdown", {method: "POST"});
+    });
+
+    const logoutBtn = createButton("Logout");
+    logoutBtn.addEventListener("click", () => {
+        sessionStorage.removeItem("token");
+        window.location.href = "/login.html";
+    });
+
+    nav.appendChild(home);
+    nav.appendChild(shutdownBtn);
+    nav.appendChild(logoutBtn);
+    return nav;
+}

--- a/web/pages/index.html
+++ b/web/pages/index.html
@@ -1,4 +1,4 @@
-<!-- File: webroot/index.html
+<!-- File: web/pages/index.html
      Author: OpenAI Assistant
      Date: October 6, 2025
      Title: Reactor dashboard page

--- a/web/pages/index.js
+++ b/web/pages/index.js
@@ -1,0 +1,24 @@
+/*
+ * File: web/pages/index.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Dashboard page script
+ * Purpose: Initializes metrics dashboard layout
+ * Reason: Entry point for authenticated monitoring page
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { renderLayout } from "/templates/layout.js";
+import { createMetricsPanel } from "/organisms/metricsPanel.js";
+
+function init() {
+    if (!sessionStorage.getItem("token")) {
+        window.location.href = "/login.html";
+        return;
+    }
+    const panel = createMetricsPanel();
+    renderLayout(panel);
+}
+
+init();

--- a/web/pages/login.html
+++ b/web/pages/login.html
@@ -1,9 +1,9 @@
-<!-- File: webroot/index.html
+<!-- File: web/pages/login.html
      Author: OpenAI Assistant
      Date: October 6, 2025
-     Title: Reactor dashboard page
-     Purpose: Provides landing page for authenticated users
-     Reason: Displays real-time metrics and controls
+     Title: Login page
+     Purpose: Presents authentication form to user
+     Reason: Allows access to protected dashboard
      Change Log:
      - 2025-10-06: Initial version
 -->
@@ -11,11 +11,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Reactor Dashboard</title>
+    <title>Login</title>
     <link rel="stylesheet" href="/atoms/styles.css">
 </head>
 <body>
     <div id="app"></div>
-    <script type="module" src="/pages/index.js"></script>
+    <script type="module" src="/pages/login.js"></script>
 </body>
 </html>

--- a/web/pages/login.js
+++ b/web/pages/login.js
@@ -1,0 +1,18 @@
+/*
+ * File: web/pages/login.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Login page script
+ * Purpose: Renders login form and handles authentication
+ * Reason: Entry point for user login workflow
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { createLoginForm } from "/molecules/loginForm.js";
+
+const app = document.getElementById("app");
+const form = createLoginForm(() => {
+    window.location.href = "/index.html";
+});
+app.appendChild(form);

--- a/web/templates/layout.js
+++ b/web/templates/layout.js
@@ -1,0 +1,20 @@
+/*
+ * File: web/templates/layout.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Layout template
+ * Purpose: Renders common layout with navigation bar
+ * Reason: Promotes reuse across pages
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { createNavBar } from "/organisms/navBar.js";
+
+export function renderLayout(content) {
+    const root = document.getElementById("app");
+    root.innerHTML = "";
+    const nav = createNavBar();
+    root.appendChild(nav);
+    root.appendChild(content);
+}

--- a/webroot/atoms/button.js
+++ b/webroot/atoms/button.js
@@ -1,0 +1,17 @@
+/*
+ * File: webroot/atoms/button.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Button atom component
+ * Purpose: Provides reusable button element for web dashboard
+ * Reason: Implements atomic design principles for UI elements
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+export function createButton(text, type = "button") {
+    const button = document.createElement("button");
+    button.type = type;
+    button.textContent = text;
+    return button;
+}

--- a/webroot/atoms/input.js
+++ b/webroot/atoms/input.js
@@ -1,0 +1,18 @@
+/*
+ * File: webroot/atoms/input.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Input atom component
+ * Purpose: Provides reusable input element for web dashboard
+ * Reason: Implements atomic design principles for UI elements
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+export function createInput(id, type = "text", placeholder = "") {
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = type;
+    input.placeholder = placeholder;
+    return input;
+}

--- a/webroot/atoms/styles.css
+++ b/webroot/atoms/styles.css
@@ -1,0 +1,43 @@
+/*
+ * File: webroot/atoms/styles.css
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Shared atomic styles
+ * Purpose: Defines CSS variables and base styles for atomic components
+ * Reason: Promotes DRY principles across UI elements
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+:root {
+    --primary-color: #4CAF50;
+    --secondary-color: #ffffff;
+    --font-family: Arial, sans-serif;
+}
+
+button {
+    background-color: var(--primary-color);
+    color: var(--secondary-color);
+    padding: 0.5rem 1rem;
+    border: none;
+    cursor: pointer;
+}
+
+input {
+    padding: 0.5rem;
+    margin: 0.25rem 0;
+    font-family: var(--font-family);
+}
+
+nav {
+    background-color: var(--primary-color);
+    color: var(--secondary-color);
+    padding: 0.5rem;
+}
+
+.status-card {
+    border: 1px solid var(--primary-color);
+    margin: 0.5rem;
+    padding: 0.5rem;
+    font-family: var(--font-family);
+}

--- a/webroot/login.html
+++ b/webroot/login.html
@@ -1,9 +1,9 @@
-<!-- File: webroot/index.html
+<!-- File: webroot/login.html
      Author: OpenAI Assistant
      Date: October 6, 2025
-     Title: Reactor dashboard page
-     Purpose: Provides landing page for authenticated users
-     Reason: Displays real-time metrics and controls
+     Title: Login page
+     Purpose: Presents authentication form to user
+     Reason: Allows access to protected dashboard
      Change Log:
      - 2025-10-06: Initial version
 -->
@@ -11,11 +11,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Reactor Dashboard</title>
+    <title>Login</title>
     <link rel="stylesheet" href="/atoms/styles.css">
 </head>
 <body>
     <div id="app"></div>
-    <script type="module" src="/pages/index.js"></script>
+    <script type="module" src="/pages/login.js"></script>
 </body>
 </html>

--- a/webroot/molecules/loginForm.js
+++ b/webroot/molecules/loginForm.js
@@ -1,0 +1,42 @@
+/*
+ * File: webroot/molecules/loginForm.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Login form molecule
+ * Purpose: Combines input and button atoms into a login form
+ * Reason: Implements authentication workflow using atomic components
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { createInput } from "/atoms/input.js";
+import { createButton } from "/atoms/button.js";
+
+export function createLoginForm(onSuccess) {
+    const form = document.createElement("form");
+    const user = createInput("username", "text", "Username");
+    const pass = createInput("password", "password", "Password");
+    const submit = createButton("Login", "submit");
+
+    form.appendChild(user);
+    form.appendChild(pass);
+    form.appendChild(submit);
+
+    form.addEventListener("submit", async (e) => {
+        e.preventDefault();
+        const response = await fetch("/api/v1/login", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({username: user.value, password: pass.value})
+        });
+        if (response.ok) {
+            const data = await response.json();
+            sessionStorage.setItem("token", data.token || "");
+            onSuccess();
+        } else {
+            alert("Login failed");
+        }
+    });
+
+    return form;
+}

--- a/webroot/molecules/statusCard.js
+++ b/webroot/molecules/statusCard.js
@@ -1,0 +1,22 @@
+/*
+ * File: webroot/molecules/statusCard.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Status card molecule
+ * Purpose: Displays labeled value for metrics
+ * Reason: Reusable component for monitoring data
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+export function createStatusCard(label, initial = "...") {
+    const card = document.createElement("div");
+    card.className = "status-card";
+    const title = document.createElement("h3");
+    title.textContent = label;
+    const value = document.createElement("p");
+    value.textContent = initial;
+    card.appendChild(title);
+    card.appendChild(value);
+    return {card, update: (val) => {value.textContent = val;}};
+}

--- a/webroot/organisms/metricsPanel.js
+++ b/webroot/organisms/metricsPanel.js
@@ -1,0 +1,37 @@
+/*
+ * File: webroot/organisms/metricsPanel.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Metrics panel organism
+ * Purpose: Displays real-time metrics with periodic fetching
+ * Reason: Provides monitoring interface for reactor data
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { createStatusCard } from "/molecules/statusCard.js";
+
+export function createMetricsPanel() {
+    const panel = document.createElement("div");
+    const power = createStatusCard("Power", "0 MW");
+    const temp = createStatusCard("Temperature", "0 C");
+    panel.appendChild(power.card);
+    panel.appendChild(temp.card);
+
+    async function updateMetrics() {
+        const response = await fetch("/api/v1/metrics");
+        if (response.ok) {
+            const data = await response.json();
+            if (data.power !== undefined) {
+                power.update(`${data.power} MW`);
+            }
+            if (data.temperature !== undefined) {
+                temp.update(`${data.temperature} C`);
+            }
+        }
+    }
+
+    updateMetrics();
+    setInterval(updateMetrics, 5000);
+    return panel;
+}

--- a/webroot/organisms/navBar.js
+++ b/webroot/organisms/navBar.js
@@ -1,0 +1,35 @@
+/*
+ * File: webroot/organisms/navBar.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Navigation bar organism
+ * Purpose: Provides application navigation and management controls
+ * Reason: Centralized user actions including logout and shutdown
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { createButton } from "/atoms/button.js";
+
+export function createNavBar() {
+    const nav = document.createElement("nav");
+    const home = document.createElement("a");
+    home.href = "/index.html";
+    home.textContent = "Dashboard";
+
+    const shutdownBtn = createButton("Shutdown");
+    shutdownBtn.addEventListener("click", async () => {
+        await fetch("/api/v1/control/shutdown", {method: "POST"});
+    });
+
+    const logoutBtn = createButton("Logout");
+    logoutBtn.addEventListener("click", () => {
+        sessionStorage.removeItem("token");
+        window.location.href = "/login.html";
+    });
+
+    nav.appendChild(home);
+    nav.appendChild(shutdownBtn);
+    nav.appendChild(logoutBtn);
+    return nav;
+}

--- a/webroot/pages/index.js
+++ b/webroot/pages/index.js
@@ -1,0 +1,24 @@
+/*
+ * File: webroot/pages/index.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Dashboard page script
+ * Purpose: Initializes metrics dashboard layout
+ * Reason: Entry point for authenticated monitoring page
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { renderLayout } from "/templates/layout.js";
+import { createMetricsPanel } from "/organisms/metricsPanel.js";
+
+function init() {
+    if (!sessionStorage.getItem("token")) {
+        window.location.href = "/login.html";
+        return;
+    }
+    const panel = createMetricsPanel();
+    renderLayout(panel);
+}
+
+init();

--- a/webroot/pages/login.js
+++ b/webroot/pages/login.js
@@ -1,0 +1,18 @@
+/*
+ * File: webroot/pages/login.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Login page script
+ * Purpose: Renders login form and handles authentication
+ * Reason: Entry point for user login workflow
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { createLoginForm } from "/molecules/loginForm.js";
+
+const app = document.getElementById("app");
+const form = createLoginForm(() => {
+    window.location.href = "/index.html";
+});
+app.appendChild(form);

--- a/webroot/templates/layout.js
+++ b/webroot/templates/layout.js
@@ -1,0 +1,20 @@
+/*
+ * File: webroot/templates/layout.js
+ * Author: OpenAI Assistant
+ * Date: October 6, 2025
+ * Title: Layout template
+ * Purpose: Renders common layout with navigation bar
+ * Reason: Promotes reuse across pages
+ * Change Log:
+ * - 2025-10-06: Initial version
+ */
+
+import { createNavBar } from "/organisms/navBar.js";
+
+export function renderLayout(content) {
+    const root = document.getElementById("app");
+    root.innerHTML = "";
+    const nav = createNavBar();
+    root.appendChild(nav);
+    root.appendChild(content);
+}


### PR DESCRIPTION
## Summary
- implement atomic design web modules and pages with login workflow, metrics polling, and management controls
- copy static dashboard assets to `webroot` for HTTP serving and document usage

## Testing
- `make cpp-build` *(fails: json/json.h: No such file or directory)*
- `make go-build`


------
https://chatgpt.com/codex/tasks/task_e_6898b9eff97c832b880cf5040a39d03a