### PR TITLE
configs: document version and streaming paths

### DIFF
--- a/configs/daemon.config
+++ b/configs/daemon.config
@@ -1,7 +1,8 @@
 # Daemon Configuration File for Ternary Fission Reactor System
 # File: configs/daemon.config
-# Author: bthlops (David StJ)  
+# Author: bthlops (David StJ)
 # Date: January 31, 2025
+# version = 2.0.0-rc1
 # Title: Complete daemon configuration for distributed physics simulation system
 # Purpose: Centralized configuration for HTTP daemon, SSL/TLS, physics engine, and logging
 # Reason: Production-ready configuration supporting distributed daemon architecture
@@ -85,6 +86,7 @@ request_size_limit = 10485760
 web_root = webroot
 
 # We enable optional media streaming using Icecast/ices2
+# Example: media_streaming_enabled = true
 media_streaming_enabled = false
 
 # We specify root directory for streaming media files

--- a/configs/ternary_fission.conf
+++ b/configs/ternary_fission.conf
@@ -2,6 +2,7 @@
 # File: configs/ternary_fission.conf
 # Author: bthlops (David StJ)
 # Date: July 31, 2025
+# version = 2.0.0-rc1
 # Title: Ternary Fission Energy Emulation System Configuration - FIXED
 # Purpose: Production configuration parameters for physics simulation and system behavior
 # Reason: Provides centralized configuration management with fixed inline comment parsing
@@ -116,10 +117,13 @@ reactor_base_url=http://127.0.0.1:8333
 status_poll_interval=15
 
 # Filesystem path for static assets
+# Example: web_root=web
 web_root=web
 
 # Media streaming configuration
+# Example: media_streaming_enabled=false
 media_streaming_enabled=false
+# Example: media_root=media
 media_root=media
 icecast_mount=/stream
 

--- a/docs/media.streaming.md
+++ b/docs/media.streaming.md
@@ -7,6 +7,7 @@ Purpose: Instructions for preparing playlists and using ices2 with the daemon
 Reason: Document new audio/video streaming capabilities
 Change Log:
 - 2025-08-10: Initial media streaming documentation
+- 2025-08-25: Add web_root example and note version 2.0.0-rc1
 -->
 
 # Media Streaming Setup
@@ -14,10 +15,13 @@ Change Log:
 The daemon can optionally stream audio or video content to an Icecast server using the `ices2` utility. Enable streaming by setting the following configuration fields:
 
 ```
+web_root = web
 media_streaming_enabled = true
 media_root = /path/to/media
 icecast_mount = /stream
 ```
+
+These options are available in version `2.0.0-rc1` and later.
 
 ## Preparing Playlists
 


### PR DESCRIPTION
## Summary
- note version 2.0.0-rc1 in daemon and simulation configs
- add example web and media streaming paths
- document streaming keys in the media streaming guide

## Testing
- `make cpp-build` *(fails: json/json.h not found)*
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*


------
https://chatgpt.com/codex/tasks/task_e_6898c6a146e0832b8cb41dc089419287