### PR TITLE
Centralize version constant usage

### DIFF
--- a/src/cpp/http.ternary.fission.server.cpp
+++ b/src/cpp/http.ternary.fission.server.cpp
@@ -684,7 +684,7 @@ void HTTPTernaryFissionServer::handleHealthCheck(const httplib::Request& /*req*/
     health["uptime_seconds"] = static_cast<Json::Int64>(uptime.count());
     health["active_energy_fields"] = static_cast<Json::Int64>(energy_fields_.size());
     health["simulation_running"] = simulation_engine_ != nullptr;
-    health["version"] = "2.0.0-rc1";
+    health["version"] = VERSION;
     health["author"] = "bthlops (David StJ)";
     
     auto now = std::chrono::system_clock::now();

--- a/src/cpp/physics.utilities.cpp
+++ b/src/cpp/physics.utilities.cpp
@@ -253,7 +253,7 @@ std::string formatHTTPResponse(const std::string& status, const std::string& mes
     timestamp_ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
     response["timestamp"] = timestamp_ss.str();
 
-    response["api_version"] = "2.0.0-rc1";
+    response["api_version"] = VERSION;
     response["server"] = "ternary-fission-daemon";
 
     Json::StreamWriterBuilder builder;

--- a/src/go/api.ternary.fission.server.go
+++ b/src/go/api.ternary.fission.server.go
@@ -47,7 +47,13 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+        "github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+    Version   = "dev"
+    BuildDate = "unknown"
+    GitCommit = "unknown"
 )
 
 // =============================================================================
@@ -1887,12 +1893,13 @@ func (s *TernaryFissionAPIServer) healthCheck(w http.ResponseWriter, r *http.Req
 	}
 	resp.Body.Close()
 
-	health := map[string]interface{}{
-		"status":               "healthy",
-		"timestamp":            time.Now().Format(time.RFC3339),
-		"uptime_seconds":       int64(uptime.Seconds()),
-		"active_energy_fields": status.ActiveEnergyFields,
-	}
+        health := map[string]interface{}{
+                "status":               "healthy",
+                "timestamp":            time.Now().Format(time.RFC3339),
+                "uptime_seconds":       int64(uptime.Seconds()),
+                "active_energy_fields": status.ActiveEnergyFields,
+                "version":              Version,
+        }
 
 	s.writeJSONResponse(w, http.StatusOK, health)
 }
@@ -1967,7 +1974,7 @@ func main() {
 
 	log.Println("=== Ternary Fission Energy Emulation API Server ===")
 	log.Printf("Author: bthlops (David StJ)")
-        log.Printf("Version: 2.0.0-rc1")
+        log.Printf("Version: %s", Version)
 	log.Printf("Starting server on port %d", config.APIPort)
 	log.Printf("🌐 Web Dashboard: http://localhost:%d/", config.APIPort)
 	log.Printf("📡 API Documentation: http://localhost:%d/api/v1", config.APIPort)


### PR DESCRIPTION
## Summary
- replace hardcoded version strings in C++ and Go with build-provided `VERSION`
- expose build metadata vars in Go and report version in API health check

## Testing
- `make cpp-build`
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*
- `curl -s http://127.0.0.1:8238/api/v1/health`


------
https://chatgpt.com/codex/tasks/task_e_6898ded65cf8832bbc8824651d5b21e8