### PR TITLE
Add portal trigger endpoint for timed energy load

### DIFF
--- a/include/http.ternary.fission.server.h
+++ b/include/http.ternary.fission.server.h
@@ -201,6 +201,7 @@ private:
     void handleSimulationStart(const httplib::Request& req, httplib::Response& res); // Start simulation
     void handleSimulationStop(const httplib::Request& req, httplib::Response& res); // Stop simulation
     void handleSimulationReset(const httplib::Request& req, httplib::Response& res); // Reset simulation
+    void handlePortalTrigger(const httplib::Request& req, httplib::Response& res); // Trigger portal load
     void handleStreamStart(const httplib::Request& req, httplib::Response& res); // Start media streaming
     void handleStreamStop(const httplib::Request& req, httplib::Response& res);  // Stop media streaming
     void handleFissionCalculation(const httplib::Request& req, httplib::Response& res); // Fission calc

--- a/include/ternary.fission.simulation.engine.h
+++ b/include/ternary.fission.simulation.engine.h
@@ -116,6 +116,15 @@ public:
     void startContinuousSimulation(double events_per_second);
     void stopContinuousSimulation();
 
+    /**
+     * Start a timed portal load at specified power level
+     * We create an energy field load that persists for the given duration
+     *
+     * @param duration_seconds: Duration of the load
+     * @param power_level_mev: Energy level in MeV
+     */
+    void startPortalLoad(double duration_seconds, double power_level_mev);
+
     Json::Value startContinuousSimulationAPI(const Json::Value& request);
     Json::Value stopContinuousSimulationAPI();
     Json::Value getSystemStatusAPI() const;


### PR DESCRIPTION
## Summary
- expose `/api/v1/portal/trigger` PUT endpoint for scheduling portal loads
- route invokes new `startPortalLoad` on the simulation engine
- respond with JSON acknowledgement of duration and projected power

## Testing
- `make cpp-build`
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*


------
https://chatgpt.com/codex/tasks/task_e_6898e5df9528832bbd9f2a397d458070