### PR TITLE
ci: restrict dev workflow trigger

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -3,47 +3,47 @@
 name: Dev Build
 
 on:
-  push:
-  pull_request:
+    push:
+        branches: [dev]
 
 jobs:
-  build:
-    name: Build on ${{ matrix.name }}
-    strategy:
-      matrix:
-        include:
-          - name: ubuntu-24.04
-            runs-on: ubuntu-24.04
-          - name: debian-12
-            runs-on: ubuntu-24.04
-            container: debian:12
-    runs-on: ${{ matrix.runs-on }}
-    container: ${{ matrix.container }}
-    env:
-      GO_VERSION: "1.23.3"
-    steps:
-      - uses: actions/checkout@v4
+    build:
+        name: Build on ${{ matrix.name }}
+        strategy:
+            matrix:
+                include:
+                    - name: ubuntu-24.04
+                      runs-on: ubuntu-24.04
+                    - name: debian-12
+                      runs-on: ubuntu-24.04
+                      container: debian:12
+        runs-on: ${{ matrix.runs-on }}
+        container: ${{ matrix.container }}
+        env:
+            GO_VERSION: "1.23.3"
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
+            - name: Set up Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: ${{ env.GO_VERSION }}
 
-      - name: Install build tools
-        run: |
-          if command -v sudo >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y build-essential gcc g++ cmake make libssl-dev pkg-config libjsoncpp-dev
-          else
-            apt-get update
-            apt-get install -y build-essential gcc g++ cmake make libssl-dev pkg-config libjsoncpp-dev
-          fi
+            - name: Install build tools
+              run: |
+                  if command -v sudo >/dev/null 2>&1; then
+                      sudo apt-get update
+                      sudo apt-get install -y build-essential gcc g++ cmake make libssl-dev pkg-config libjsoncpp-dev
+                  else
+                      apt-get update
+                      apt-get install -y build-essential gcc g++ cmake make libssl-dev pkg-config libjsoncpp-dev
+                  fi
 
-      - name: Verify jsoncpp pkg-config
-        run: pkg-config --cflags --libs jsoncpp
+            - name: Verify jsoncpp pkg-config
+              run: pkg-config --cflags --libs jsoncpp
 
-      - name: Build C++ components
-        run: make cpp-build
+            - name: Build C++ components
+              run: make cpp-build
 
-      - name: Build Go components
-        run: make go-build
+            - name: Build Go components
+              run: make go-build


### PR DESCRIPTION
## Summary
- run dev workflow only on dev branch pushes

## Testing
- `make cpp-build`
- `make go-build`


------
https://chatgpt.com/codex/tasks/task_e_68990d7d4aa0832b99bbc964e396ed71