### PR TITLE
ci: add future branch workflow

### DIFF
--- a/.github/workflows/future.yaml
+++ b/.github/workflows/future.yaml
@@ -1,0 +1,51 @@
+# File: .github/workflows/future.yaml
+# Purpose: Future branch build verification
+name: Future Build
+
+on:
+    push:
+        branches: [future]
+    pull_request:
+        branches: [future]
+
+jobs:
+    build:
+        name: Build on ${{ matrix.name }}
+        strategy:
+            matrix:
+                include:
+                    - name: ubuntu-24.04
+                      runs-on: ubuntu-24.04
+                    - name: debian-12
+                      runs-on: ubuntu-24.04
+                      container: debian:12
+        runs-on: ${{ matrix.runs-on }}
+        container: ${{ matrix.container }}
+        env:
+            GO_VERSION: "1.23.3"
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: ${{ env.GO_VERSION }}
+
+            - name: Install build tools
+              run: |
+                  if command -v sudo >/dev/null 2>&1; then
+                      sudo apt-get update
+                      sudo apt-get install -y build-essential gcc g++ cmake make libssl-dev pkg-config libjsoncpp-dev
+                  else
+                      apt-get update
+                      apt-get install -y build-essential gcc g++ cmake make libssl-dev pkg-config libjsoncpp-dev
+                  fi
+
+            - name: Verify jsoncpp pkg-config
+              run: pkg-config --cflags --libs jsoncpp
+
+            - name: Build C++ components
+              run: make cpp-build
+
+            - name: Build Go components
+              run: make go-build


### PR DESCRIPTION
## Summary
- add future branch CI workflow mirroring dev

## Testing
- `make cpp-build`
- `make go-build`


------
https://chatgpt.com/codex/tasks/task_e_689913a531d8832bae03843a17aaf968