### PR TITLE
Limit build release workflow to master

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -15,7 +15,9 @@ name: Build and Release Pipeline
 
 on:
   push:
-    branches: [ master, main, develop, dev ]
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Restrict build and release workflow triggers to master for both pushes and pull requests
- Allow manual workflow dispatch

## Testing
- `make cpp-build`
- `make go-build`


------
https://chatgpt.com/codex/tasks/task_e_689914d1f520832b96a08ad0fbe5cc78