### PR TITLE
workflow: compute release version from dev runs

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -46,45 +46,58 @@ jobs:
         
     - name: Calculate version
       id: version
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        BUILD_NUM=${{ github.run_number }}
-        
-        # We implement version rollover logic
-        if [[ "${{ github.ref_name }}" == "master" ]] || [[ "${{ github.ref_name }}" == "main" ]]; then
-          # Production versioning with rollover logic
-          if [[ $BUILD_NUM -ge 25 && $BUILD_NUM -lt 100 ]]; then
-            # v1.1.25+ becomes v1.2.1-beta
-            BETA_NUM=$((BUILD_NUM - 24))
-            VERSION="1.2.${BETA_NUM}-beta"
-          elif [[ $BUILD_NUM -ge 100 ]]; then
-            # v1.2.100+ becomes v1.3.1+ gold
-            GOLD_NUM=$((BUILD_NUM - 99))
-            VERSION="1.3.${GOLD_NUM}"
-          else
-            # v1.1.1-24 stays alpha
-            VERSION="1.1.${BUILD_NUM}"
-          fi
-          IS_PROD="true"
+        API="https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-and-release.yml/runs"
+        BASE_URL="${API}?branch=dev&status=success&per_page=5"
+        count=0
+        prev=0
+        page=1
+
+        while true; do
+            data=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$BASE_URL&page=$page")
+            runs=$(echo "$data" | jq '.workflow_runs')
+            len=$(echo "$runs" | jq 'length')
+            [ "$len" -eq 0 ] && break
+            for run in $(echo "$runs" | jq '.[].run_number'); do
+                if [ "$count" -eq 0 ]; then
+                    prev=$run
+                    count=1
+                else
+                    expected=$((prev - 1))
+                    if [ "$run" -eq "$expected" ]; then
+                        count=$((count + 1))
+                        prev=$run
+                    else
+                        len=0
+                        break
+                    fi
+                fi
+            done
+            [ "$len" -eq 0 ] && break
+            [ "$count" -gt 10 ] && break
+            page=$((page + 1))
+        done
+
+        if [ "$count" -lt 5 ]; then
+            VERSION="2.0.${count}-beta"
+            IS_PROD="false"
+        elif [ "$count" -le 10 ]; then
+            VERSION="2.0.0-rc${count}"
+            IS_PROD="false"
         else
-          # Development versioning
-          if [[ $BUILD_NUM -ge 25 && $BUILD_NUM -lt 100 ]]; then
-            BETA_NUM=$((BUILD_NUM - 24))
-            VERSION="1.2.${BETA_NUM}-beta-dev"
-          elif [[ $BUILD_NUM -ge 100 ]]; then
-            GOLD_NUM=$((BUILD_NUM - 99))
-            VERSION="1.3.${GOLD_NUM}-dev"
-          else
-            VERSION="1.1.${BUILD_NUM}-alpha-dev"
-          fi
-          IS_PROD="false"
+            prod=$((count - 10))
+            VERSION="2.0.${prod}"
+            IS_PROD="true"
         fi
-        
+
         TAG="v${VERSION}"
-        
+
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "tag=$TAG" >> $GITHUB_OUTPUT
         echo "is_prod=$IS_PROD" >> $GITHUB_OUTPUT
-        echo "Generated version: $VERSION for branch ${{ github.ref_name }} (build #$BUILD_NUM)"
+        echo "Calculated version: $VERSION based on $count consecutive successes"
 
   # We build the application
   build:


### PR DESCRIPTION
## Summary
- use GitHub API to gather recent `dev` branch runs and derive version/tag/is_prod values

## Testing
- `make cpp-build`
- `make go-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*

------
https://chatgpt.com/codex/tasks/task_e_689916e7ebfc832b9e8d842ce19d0baf