### PR TITLE
ci: add deb packaging

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -113,8 +113,9 @@ jobs:
         sudo apt update
         sudo apt install -y \
           build-essential gcc-13 g++-13 cmake make \
-          libssl-dev libboost-all-dev git zip tar gzip
-          
+          libssl-dev libboost-all-dev git zip tar gzip \
+          dpkg-dev
+
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
         
@@ -139,17 +140,17 @@ jobs:
     - name: Package artifacts
       run: |
         mkdir -p artifacts/${{ needs.version.outputs.version }}
-        
+
         # Copy binaries if they exist
         cp bin/* artifacts/${{ needs.version.outputs.version }}/ 2>/dev/null || echo "No binaries found"
-        
+
         # Copy configs and docs
         cp -r configs artifacts/${{ needs.version.outputs.version }}/ 2>/dev/null || echo "No configs"
         cp README.md artifacts/${{ needs.version.outputs.version }}/ 2>/dev/null || echo "No README"
         cp BUILD_CARRYOVER.md artifacts/${{ needs.version.outputs.version }}/ 2>/dev/null || echo "No BUILD_CARRYOVER"
         cp LICENSE artifacts/${{ needs.version.outputs.version }}/ 2>/dev/null || echo "No LICENSE"
         cp HOWTO.md artifacts/${{ needs.version.outputs.version }}/ 2>/dev/null || echo "No HOWTO"
-        
+
         # Create version file
         cat > artifacts/${{ needs.version.outputs.version }}/VERSION << EOF
         Version: ${{ needs.version.outputs.version }}
@@ -159,12 +160,30 @@ jobs:
         Build Type: ${{ needs.version.outputs.is_prod == 'true' && 'Production' || 'Development' }}
         Platform: Ubuntu 24.04 x86_64
         EOF
-        
+
+        # Build Debian packages for Debian and Ubuntu
+        for distro in debian ubuntu; do
+            pkg_dir="package_$distro"
+            mkdir -p "$pkg_dir/DEBIAN" "$pkg_dir/usr/local/bin"
+            cat > "$pkg_dir/DEBIAN/control" << EOC
+        Package: ${{ env.PROJECT_NAME }}
+        Version: ${{ needs.version.outputs.version }}
+        Section: utils
+        Priority: optional
+        Architecture: amd64
+        Maintainer: Ternary Fission Reactor Team
+        Description: Ternary Fission Reactor binaries
+        EOC
+            cp bin/* "$pkg_dir/usr/local/bin/" 2>/dev/null || echo "No binaries"
+            dpkg-deb --build "$pkg_dir" "artifacts/${{ env.PROJECT_NAME }}-${{ needs.version.outputs.version }}-${distro}.deb"
+            rm -rf "$pkg_dir"
+        done
+
         # Create archives
         cd artifacts
         tar -czf ${{ env.PROJECT_NAME }}-${{ needs.version.outputs.version }}.tar.gz ${{ needs.version.outputs.version }}/
         zip -r ${{ env.PROJECT_NAME }}-${{ needs.version.outputs.version }}.zip ${{ needs.version.outputs.version }}/
-        sha256sum *.tar.gz *.zip > SHA256SUMS
+        sha256sum *.tar.gz *.zip *.deb > SHA256SUMS
         cd ..
         
     - name: Upload artifacts
@@ -234,10 +253,11 @@ jobs:
     - name: Prepare release assets
       run: |
         mkdir -p release-assets
-        
+
         # Copy all artifacts
         cp release-binaries/*.tar.gz release-assets/ 2>/dev/null || echo "No binary tar.gz"
-        cp release-binaries/*.zip release-assets/ 2>/dev/null || echo "No binary zip" 
+        cp release-binaries/*.zip release-assets/ 2>/dev/null || echo "No binary zip"
+        cp release-binaries/*.deb release-assets/ 2>/dev/null || echo "No binary deb"
         cp release-source/*.tar.gz release-assets/ 2>/dev/null || echo "No source tar.gz"
         cp release-source/*.zip release-assets/ 2>/dev/null || echo "No source zip"
         cp release-binaries/SHA256SUMS release-assets/SHA256SUMS-BINARIES 2>/dev/null || echo "No binary checksums"
@@ -305,6 +325,8 @@ jobs:
         - **Platform**: Ubuntu 24.04 x86_64
         
         ### Download
+        - Debian Package: \`${{ env.PROJECT_NAME }}-${{ needs.version.outputs.version }}-debian.deb\`
+        - Ubuntu Package: \`${{ env.PROJECT_NAME }}-${{ needs.version.outputs.version }}-ubuntu.deb\`
         - Binary Package (tar.gz): \`${{ env.PROJECT_NAME }}-${{ needs.version.outputs.version }}.tar.gz\`
         - Binary Package (zip): \`${{ env.PROJECT_NAME }}-${{ needs.version.outputs.version }}.zip\`
         - Source Code (tar.gz): \`${{ env.PROJECT_NAME }}-${{ needs.version.outputs.version }}-source.tar.gz\`


### PR DESCRIPTION
## Summary
- build Debian/Ubuntu `.deb` packages during CI and release
- upload `.deb` packages with checksums in release artifacts

## Testing
- `make cpp-build` *(fails: json/json.h: No such file or directory)*
- `make go-build` *(fails: Package jsoncpp was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68991938ec48832b88183c25863118d8