### PR TITLE
docs: add benchmarking presets and references

### DIFF
--- a/HOW-TO.md
+++ b/HOW-TO.md
@@ -543,6 +543,24 @@ export TERNARY_LOG_LEVEL=debug
 ./ternary-fission -n 50000
 ```
 
+## 🏁 Benchmarking
+
+See [docs/BENCHMARKING.md](docs/BENCHMARKING.md) for preset definitions.
+
+```bash
+# Small
+./ternary-fission --preset small
+
+# Medium
+./ternary-fission --preset medium
+
+# Large
+./ternary-fission --preset large
+
+# Extra Large
+./ternary-fission --preset xlarge
+```
+
 ## ✅ Validation and Verification
 
 ### Conservation Law Checking

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The system emulates ternary nuclear fission to explore how computational resourc
 - Distributed daemon architecture bridging C++ and Go components
 - Docker-first deployment with real-time monitoring stack
 - Kubernetes-ready configuration and release workflows
-- See [ARCH.md](ARCH.md), [HOW-TO.md](HOW-TO.md), and [NEXT-STEPS.md](NEXT-STEPS.md) for RC milestone details
+- See [ARCH.md](ARCH.md), [HOW-TO.md](HOW-TO.md), [docs/BENCHMARKING.md](docs/BENCHMARKING.md), and [NEXT-STEPS.md](NEXT-STEPS.md) for RC milestone details
 
 ## Architecture
 
@@ -124,6 +124,7 @@ Open `http://localhost:8333/login.html` to authenticate and reach the dashboard.
 ## Related Documentation
 
 - [HOW-TO.md](HOW-TO.md) - Complete usage guide with examples from basic to extreme simulations
+- [docs/BENCHMARKING.md](docs/BENCHMARKING.md) - Benchmark presets for repeatable runs
 - [TESTING.md](TESTING.md) - Docker testing procedures and verification commands
 - [NEXT-STEPS.md](NEXT-STEPS.md) - Development roadmap and technical debt analysis
 - [BUILD_CARRYOVER.md](BUILD_CARRYOVER.md) - Development context and architecture overview
@@ -444,6 +445,7 @@ make test-integration
 
 ### Technical Documentation
 - **[HOW-TO.md](HOW-TO.md)** - Complete usage guide from basic to extreme simulations
+- **[docs/BENCHMARKING.md](docs/BENCHMARKING.md)** - Benchmark presets for repeatable runs
 - **[TESTING.md](TESTING.md)** - Docker testing procedures and API verification
 - **[NEXT-STEPS.md](NEXT-STEPS.md)** - Development roadmap and architecture improvements
 - **[BUILD_CARRYOVER.md](BUILD_CARRYOVER.md)** - Development context and system overview

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -1,0 +1,25 @@
+# Benchmarking Presets
+
+**Author:** bthlops (David StJ)
+**Date:** August 10, 2025
+**Title:** Benchmarking presets for event-driven fission simulation runs
+**Purpose:** Provide standardized presets for repeatable benchmarking
+**Reason:** Simplify performance comparison across common scenarios
+**Change Log:**
+- 2025-08-10: Initial creation
+
+| Preset | Events | Duration | Power Multiplier |
+|--------|--------|----------|------------------|
+| small  | 1,000  | 10 s     | 1x               |
+| medium | 10,000 | 1 m      | 2x               |
+| large  | 100,000 | 5 m     | 5x               |
+| xlarge | 1,000,000 | 30 m  | 10x              |
+
+Each preset configures the simulation with a predefined number of events, run time, and power multiplier. Use these settings to ensure consistent comparisons across runs.
+
+Example usage:
+
+```bash
+# Run with the medium preset
+./ternary-fission --preset medium
+```


### PR DESCRIPTION
## Summary
- add benchmarking presets documentation
- reference benchmarking guide from HOW-TO and README

## Testing
- `make cpp-build`
- `make go-build`


------
https://chatgpt.com/codex/tasks/task_e_689925ee9ac0832b8b8849bd3943417a