### PR TITLE
docs: add math primer and references

### DIFF
--- a/HOW-TO.md
+++ b/HOW-TO.md
@@ -6,6 +6,8 @@
 **Purpose:** Comprehensive examples from basic to extreme simulation scenarios including verified Docker workflows
 **Reason:** Updated guide reflecting current working status with Docker Compose operational and Go API server confirmed functional
 
+See [docs/MATH_PRIMER.md](docs/MATH_PRIMER.md) for the multi-base arithmetic driving energy distribution.
+
 **Change Log:**
 - 2025-07-31: Updated with working Docker Compose deployment and verified API endpoints
 - 2025-07-31: Added Docker testing procedures and container-based workflows

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Open `http://localhost:8333/login.html` to authenticate and reach the dashboard.
 ## Related Documentation
 
 - [HOW-TO.md](HOW-TO.md) - Complete usage guide with examples from basic to extreme simulations
+- [docs/MATH_PRIMER.md](docs/MATH_PRIMER.md) - Base-3/5/8/17 arithmetic for energy distribution
 - [docs/BENCHMARKING.md](docs/BENCHMARKING.md) - Benchmark presets for repeatable runs
 - [TESTING.md](TESTING.md) - Docker testing procedures and verification commands
 - [NEXT-STEPS.md](NEXT-STEPS.md) - Development roadmap and technical debt analysis

--- a/docs/MATH_PRIMER.md
+++ b/docs/MATH_PRIMER.md
@@ -1,0 +1,40 @@
+# Multi-Base Arithmetic Primer
+
+**Author:** bthlops (David StJ)
+**Date:** August 10, 2025
+**Title:** Base 3, 5, 8, and 17 arithmetic fundamentals
+**Purpose:** Explain multi-base math for energy distribution
+**Reason:** Provide reference for base systems used in reactor simulation
+**Change Log:**
+- 2025-08-10: Initial creation
+
+## Base 3 (Ternary)
+
+    - Digits: 0, 1, 2
+    - Example addition: 2 + 2 = 11₃
+    - Suits three-way energy partitioning in reactor fuel cells.
+
+## Base 5 (Quinary)
+
+    - Digits: 0, 1, 2, 3, 4
+    - Example multiplication: 3 × 4 = 22₅
+    - Models five discrete moderation states for neutron flux control.
+
+## Base 8 (Octal)
+
+    - Digits: 0 through 7
+    - Example conversion: 77₁₀ = 115₈
+    - Aligns with byte-oriented storage for rapid telemetry mapping.
+
+## Base 17 (Heptadecimal)
+
+    - Digits: 0-9, A-G
+    - Example subtraction: 20₁₇ − G₁₇ = 13₁₇
+    - Prime base spreads heat-load factors evenly across nodes.
+
+## Energy Distribution Rationale
+
+    - Bases combine so that ternary splitting feeds quinary moderators.
+    - Octal mapping packs readings into byte-aligned buffers.
+    - Heptadecimal layers prime symmetry over grid routing, minimizing
+        resonance and ensuring balanced energy distribution.


### PR DESCRIPTION
## Summary
- document base-3,5,8,17 arithmetic and reactor energy mapping
- link math primer from README and HOW-TO guides

## Testing
- `make cpp-build`
- `make go-build`


------
https://chatgpt.com/codex/tasks/task_e_68992cc5bef8832ba03d54ef3310c113