### PR TITLE
docs: add wormhole physics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 High-performance ternary nuclear fission simulation with C++ physics engine, Go REST API, and Docker deployment. Maps nuclear energy to computational resources with real-time monitoring and conservation law verification using multi-base mathematical frameworks.
 
+A speculative [Wormhole Physics](docs/PHYSICS.md#wormhole-physics) section surveys Einstein–Rosen bridges, Lorentzian wormholes, and quantum computing feasibility.
+
 
 ## Overview
 

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -1,0 +1,32 @@
+# Physics Reference
+
+**Author:** OpenAI ChatGPT
+**Date:** August 11, 2025
+**Title:** Physics reference for advanced models
+**Purpose:** Provide theoretical context for exotic spacetime research
+**Reason:** Document wormhole models relevant to future simulation modules
+**Change Log:**
+- 2025-08-11: Initial creation with wormhole physics section
+
+## Wormhole Physics
+
+Einstein and Rosen first described bridges in spacetime linking separate regions through solutions to the general relativity field equations. These **Einstein–Rosen bridges** emerge from extending the Schwarzschild metric but collapse before traversal, serving primarily as mathematical curiosities rather than practical transport mechanisms.
+
+Building on this framework, Morris and Thorne demonstrated that **Lorentzian wormholes** could, in principle, remain open if supported by exotic matter violating the averaged null energy condition. Such configurations raise stability issues and demand forms of negative energy density not yet observed in nature.
+
+Recent analyses explore whether **stable quantum computing** could orchestrate the precise energy distributions required to stabilize microscopic wormholes. Quantum error correction and entanglement resources might manage exotic matter dynamics, yet no architecture has verified this feasibility.
+
+### References
+
+- A. Einstein and N. Rosen, *The Particle Problem in the General Theory of Relativity*, Phys. Rev. 48, 73 (1935).
+- M. Morris and K. Thorne, *Wormholes in spacetime and their use for interstellar travel: A tool for teaching general relativity*, Am. J. Phys. 56, 395 (1988).
+
+### Open Questions
+
+1. Can quantum fields generate sustained negative energy without violating quantum inequalities?
+2. What error correction overhead would a wormhole-stabilizing quantum computer require?
+3. How would backreaction from traversable wormholes alter classical spacetime metrics?
+
+### Prospects for Practical Realization
+
+While speculative, advances in quantum information theory and experimental platforms may eventually permit tabletop tests of wormhole-like effects. Demonstrating controlled negative energy or entanglement-assisted spacetime engineering would mark incremental steps toward any practical wormhole system.


### PR DESCRIPTION
## Summary
- document Einstein–Rosen bridges, Lorentzian wormholes, and quantum-computing stabilization in new `docs/PHYSICS.md`
- link README to Wormhole Physics overview

## Testing
- `make cpp-build`
- `make go-build`


------
https://chatgpt.com/codex/tasks/task_e_68993ab2de34832bb86241a6d2cd0e00