### PR TITLE
tls: load certificate chain and key from config

### DIFF
--- a/configs/daemon.config
+++ b/configs/daemon.config
@@ -42,20 +42,15 @@ bind_port = 8333
 # SSL requires valid certificate and private key files configured below
 enable_ssl = false
 
-# We specify SSL certificate file path for HTTPS operation
-# Certificate must be PEM format, can be single cert or full chain
+# We specify SSL certificate chain file path for HTTPS operation
+# Certificate must include the full chain in PEM format
 # Leave empty to disable SSL or use auto-detection from standard paths
-ssl_cert_path = /etc/ssl/certs/ternary-fission.crt
+ssl_cert_chain = /etc/ssl/beyondthehorizonlabs.com/fullchain.pem
 
-# We specify SSL private key file path for HTTPS operation  
-# Private key must be PEM format and match the certificate
+# We specify SSL private key file path for HTTPS operation
+# Private key must be PEM format and match the certificate chain
 # Ensure proper file permissions (600) for security
-ssl_key_path = /etc/ssl/private/ternary-fission.key
-
-# We specify SSL CA certificate or chain file path
-# Used for client certificate verification and chain validation
-# Optional for most deployments, required for client certificate auth
-ssl_ca_path = /etc/ssl/certs/ternary-fission-ca.crt
+ssl_private_key = /etc/ssl/beyondthehorizonlabs.com/beyondthehorizonlabs.com.key
 
 # We set maximum concurrent HTTP connections
 # Adjust based on server capacity and expected load

--- a/configs/ternary_fission.conf
+++ b/configs/ternary_fission.conf
@@ -220,8 +220,8 @@ secure_cookies=true
 
 # SSL/TLS configuration
 ssl_enabled=true
-ssl_certificate_path=/etc/ssl/bthl/ternary-fission-server.crt
-ssl_private_key_path=/etc/ssl/bthl/ternary-fission-server.key
+ssl_cert_chain=/etc/ssl/beyondthehorizonlabs.com/fullchain.pem
+ssl_private_key=/etc/ssl/beyondthehorizonlabs.com/beyondthehorizonlabs.com.key
 ssl_cipher_suite=ECDHE-RSA-AES256-GCM-SHA384
 
 # Operational modes

--- a/include/config.ternary.fission.server.h
+++ b/include/config.ternary.fission.server.h
@@ -3,21 +3,24 @@
  * Author: bthlops (David StJ)
  * Date: January 31, 2025
  * Title: Configuration Management System for Ternary Fission Daemon Server
- * Purpose: Handles configuration file parsing, validation, and runtime management for daemon operations
- * Reason: Provides centralized configuration management supporting HTTP daemon mode and SSL/TLS operations
+ * Purpose: Handles configuration file parsing, validation, and runtime
+ * management for daemon operations Reason: Provides centralized configuration
+ * management supporting HTTP daemon mode and SSL/TLS operations
  *
  * Change Log:
- * 2025-01-31: Initial implementation for distributed daemon architecture Phase 1
- *             Added complete configuration parsing for daemon mode operations
- *             Implemented SSL/TLS certificate management and validation
- *             Added network configuration options for HTTP server binding
- *             Integrated physics parameter validation with theoretical constraints
- *             Added platform-specific path handling for certificate management
+ * 2025-01-31: Initial implementation for distributed daemon architecture Phase
+ * 1 Added complete configuration parsing for daemon mode operations Implemented
+ * SSL/TLS certificate management and validation Added network configuration
+ * options for HTTP server binding Integrated physics parameter validation with
+ * theoretical constraints Added platform-specific path handling for certificate
+ * management
  *
  * Carry-over Context:
  * - This class supports the distributed daemon architecture outlined in ARCH.md
- * - Configuration format matches Go server format for consistency across services
- * - SSL certificate paths are validated and certificates are checked for validity
+ * - Configuration format matches Go server format for consistency across
+ * services
+ * - SSL certificate paths are validated and certificates are checked for
+ * validity
  * - Physics parameters are validated against theoretical constraints
  * - Environment variable overrides follow hybrid configuration strategy
  * - Next: Integration with daemon and HTTP server classes for complete service
@@ -25,27 +28,28 @@
 #ifndef CONFIG_TERNARY_FISSION_SERVER_H
 #define CONFIG_TERNARY_FISSION_SERVER_H
 
-#include <string>
-#include <map>
-#include <vector>
-#include <memory>
 #include <chrono>
-#include <mutex>
 #include <fstream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 namespace TernaryFission {
 
 /**
  * We define configuration categories for organized parameter management
- * Each category groups related configuration parameters for validation and access
+ * Each category groups related configuration parameters for validation and
+ * access
  */
 enum class ConfigCategory {
-    DAEMON_CONFIG,      // Daemon process management settings
-    NETWORK_CONFIG,     // HTTP server and network binding settings
-    SSL_CONFIG,         // SSL/TLS certificate and encryption settings
-    PHYSICS_CONFIG,     // Physics simulation and mathematical parameters
-    LOGGING_CONFIG,     // Log file management and output settings
-    PERFORMANCE_CONFIG  // Threading and resource allocation settings
+  DAEMON_CONFIG,     // Daemon process management settings
+  NETWORK_CONFIG,    // HTTP server and network binding settings
+  SSL_CONFIG,        // SSL/TLS certificate and encryption settings
+  PHYSICS_CONFIG,    // Physics simulation and mathematical parameters
+  LOGGING_CONFIG,    // Log file management and output settings
+  PERFORMANCE_CONFIG // Threading and resource allocation settings
 };
 
 /**
@@ -53,22 +57,21 @@ enum class ConfigCategory {
  * This structure contains all parameters needed for daemon network operations
  */
 struct NetworkConfiguration {
-    std::string bind_ip = "127.0.0.1";          // Network interface to bind
-    int bind_port = 8333;                       // HTTP/HTTPS port number
-    bool enable_ssl = false;                    // SSL/TLS enablement flag
-    std::string ssl_cert_path;                  // Path to SSL certificate file
-    std::string ssl_key_path;                   // Path to SSL private key file
-    std::string ssl_ca_path;                    // Path to SSL CA certificate or chain
-    int max_connections = 1000;                 // Maximum concurrent connections
-    int connection_timeout = 30;                // Connection timeout in seconds
-    bool enable_cors = true;                    // Cross-Origin Resource Sharing
-    std::vector<std::string> cors_origins;      // Allowed CORS origins
-    int request_size_limit = 10485760;          // Maximum request size (10MB)
-    std::string web_root;                       // Filesystem path for static assets
+  std::string bind_ip = "127.0.0.1";     // Network interface to bind
+  int bind_port = 8333;                  // HTTP/HTTPS port number
+  bool enable_ssl = false;               // SSL/TLS enablement flag
+  std::string ssl_cert_chain;            // Path to SSL certificate chain file
+  std::string ssl_private_key;           // Path to SSL private key file
+  int max_connections = 1000;            // Maximum concurrent connections
+  int connection_timeout = 30;           // Connection timeout in seconds
+  bool enable_cors = true;               // Cross-Origin Resource Sharing
+  std::vector<std::string> cors_origins; // Allowed CORS origins
+  int request_size_limit = 10485760;     // Maximum request size (10MB)
+  std::string web_root;                  // Filesystem path for static assets
 
-    NetworkConfiguration() {
-        cors_origins = {"*"};  // Default to allow all origins
-    }
+  NetworkConfiguration() {
+    cors_origins = {"*"}; // Default to allow all origins
+  }
 };
 
 /**
@@ -76,15 +79,16 @@ struct NetworkConfiguration {
  * This structure controls daemon lifecycle and system integration
  */
 struct DaemonConfiguration {
-    bool daemon_mode = false;                   // Enable daemon background operation
-    std::string pid_file_path = "/tmp/ternary-fission-daemon.pid";
-    std::string working_directory = "/";        // Daemon working directory
-    std::string user_name;                      // User to run daemon as
-    std::string group_name;                     // Group to run daemon as
-    int umask_value = 022;                      // File creation mask
-    bool create_pid_file = true;                // Create PID file for process tracking
-    int shutdown_timeout = 30;                  // Graceful shutdown timeout seconds
-    std::vector<std::string> signal_handlers;   // Custom signal handler configuration
+  bool daemon_mode = false; // Enable daemon background operation
+  std::string pid_file_path = "/tmp/ternary-fission-daemon.pid";
+  std::string working_directory = "/"; // Daemon working directory
+  std::string user_name;               // User to run daemon as
+  std::string group_name;              // Group to run daemon as
+  int umask_value = 022;               // File creation mask
+  bool create_pid_file = true;         // Create PID file for process tracking
+  int shutdown_timeout = 30;           // Graceful shutdown timeout seconds
+  std::vector<std::string>
+      signal_handlers; // Custom signal handler configuration
 };
 
 /**
@@ -92,15 +96,15 @@ struct DaemonConfiguration {
  * This structure handles all SSL/TLS certificate validation and loading
  */
 struct SSLConfiguration {
-    bool ssl_enabled = false;                   // Master SSL enable flag
-    std::string certificate_file;               // SSL certificate file path
-    std::string private_key_file;               // SSL private key file path
-    std::string ca_certificate_file;            // CA certificate or chain file
-    std::string cipher_suite;                   // SSL cipher suite specification
-    bool verify_client_certificates = false;    // Client certificate verification
-    int ssl_protocol_version = 0;              // SSL/TLS protocol version (0=auto)
-    std::chrono::system_clock::time_point cert_expiry; // Certificate expiry tracking
-    bool auto_reload_certificates = true;       // Automatically reload on change
+  bool ssl_enabled = false;                // Master SSL enable flag
+  std::string certificate_file;            // SSL certificate chain file path
+  std::string private_key_file;            // SSL private key file path
+  std::string cipher_suite;                // SSL cipher suite specification
+  bool verify_client_certificates = false; // Client certificate verification
+  int ssl_protocol_version = 0;            // SSL/TLS protocol version (0=auto)
+  std::chrono::system_clock::time_point
+      cert_expiry;                      // Certificate expiry tracking
+  bool auto_reload_certificates = true; // Automatically reload on change
 };
 
 /**
@@ -108,15 +112,15 @@ struct SSLConfiguration {
  * This structure validates physics parameters against theoretical constraints
  */
 struct PhysicsConfiguration {
-    double default_parent_mass = 235.0;         // Default nuclear mass (AMU)
-    double default_excitation_energy = 6.5;     // Default excitation energy (MeV)
-    double max_energy_field = 1000.0;          // Maximum energy field (MeV)
-    double min_energy_field = 0.1;             // Minimum energy field (MeV)
-    int default_thread_count = 0;              // Physics calculation threads (0=auto)
-    double conservation_tolerance = 1e-6;       // Conservation law tolerance
-    bool enable_conservation_checks = true;     // Enable conservation verification
-    double events_per_second = 5.0;            // Default simulation rate
-    int max_events_per_request = 100000;       // Maximum events in single request
+  double default_parent_mass = 235.0;     // Default nuclear mass (AMU)
+  double default_excitation_energy = 6.5; // Default excitation energy (MeV)
+  double max_energy_field = 1000.0;       // Maximum energy field (MeV)
+  double min_energy_field = 0.1;          // Minimum energy field (MeV)
+  int default_thread_count = 0;         // Physics calculation threads (0=auto)
+  double conservation_tolerance = 1e-6; // Conservation law tolerance
+  bool enable_conservation_checks = true; // Enable conservation verification
+  double events_per_second = 5.0;         // Default simulation rate
+  int max_events_per_request = 100000;    // Maximum events in single request
 };
 
 /**
@@ -124,263 +128,280 @@ struct PhysicsConfiguration {
  * This structure controls all logging behavior and file management
  */
 struct LoggingConfiguration {
-    std::string log_level = "info";            // Logging verbosity level
-    std::string access_log_path = "logs/daemon-access.log";
-    std::string error_log_path = "logs/daemon-error.log";
-    std::string debug_log_path = "logs/daemon-debug.log";
-    bool enable_console_logging = true;        // Enable console output
-    bool enable_file_logging = true;           // Enable file output
-    int max_log_file_size = 104857600;         // Maximum log file size (100MB)
-    int log_rotation_count = 10;               // Number of rotated log files to keep
-    bool enable_json_logging = false;          // Enable structured JSON logging
-    bool verbose_output = false;               // Enable verbose logging output
-    std::string log_timestamp_format = "%Y-%m-%d %H:%M:%S"; // Log timestamp format
+  std::string log_level = "info"; // Logging verbosity level
+  std::string access_log_path = "logs/daemon-access.log";
+  std::string error_log_path = "logs/daemon-error.log";
+  std::string debug_log_path = "logs/daemon-debug.log";
+  bool enable_console_logging = true; // Enable console output
+  bool enable_file_logging = true;    // Enable file output
+  int max_log_file_size = 104857600;  // Maximum log file size (100MB)
+  int log_rotation_count = 10;        // Number of rotated log files to keep
+  bool enable_json_logging = false;   // Enable structured JSON logging
+  bool verbose_output = false;        // Enable verbose logging output
+  std::string log_timestamp_format =
+      "%Y-%m-%d %H:%M:%S"; // Log timestamp format
 };
 
 /**
- * We define media streaming configuration structure for external audio/video feeds
- * This structure controls streaming tool invocation and media file locations
+ * We define media streaming configuration structure for external audio/video
+ * feeds This structure controls streaming tool invocation and media file
+ * locations
  */
 struct MediaStreamingConfiguration {
-    bool media_streaming_enabled = false;      // Enable media streaming subsystem
-    std::string media_root;                    // Root directory for media files
-    std::string icecast_mount;                 // Target Icecast mount point
+  bool media_streaming_enabled = false; // Enable media streaming subsystem
+  std::string media_root;               // Root directory for media files
+  std::string icecast_mount;            // Target Icecast mount point
 };
 
 /**
- * We define the main configuration manager class for centralized parameter management
- * This class handles loading, parsing, validation, and runtime updates of all configuration
+ * We define the main configuration manager class for centralized parameter
+ * management This class handles loading, parsing, validation, and runtime
+ * updates of all configuration
  */
 class ConfigurationManager {
 private:
-    std::string config_file_path_;              // Path to configuration file
-    std::map<std::string, std::string> raw_config_; // Raw configuration key-value pairs
-    std::chrono::system_clock::time_point last_modified_; // File modification time
-    mutable std::mutex config_mutex_;           // Thread-safe configuration access
-    bool auto_reload_enabled_ = false;          // Automatic configuration reloading
-    
-    // We store parsed configuration structures
-    NetworkConfiguration network_config_;
-    DaemonConfiguration daemon_config_;
-    SSLConfiguration ssl_config_;
-    PhysicsConfiguration physics_config_;
-    LoggingConfiguration logging_config_;
-    MediaStreamingConfiguration media_streaming_config_;
-    
-    // We track configuration validation status
-    bool configuration_valid_ = false;
-    std::vector<std::string> validation_errors_;
-    std::vector<std::string> validation_warnings_;
+  std::string config_file_path_; // Path to configuration file
+  std::map<std::string, std::string>
+      raw_config_; // Raw configuration key-value pairs
+  std::chrono::system_clock::time_point
+      last_modified_;                // File modification time
+  mutable std::mutex config_mutex_;  // Thread-safe configuration access
+  bool auto_reload_enabled_ = false; // Automatic configuration reloading
+
+  // We store parsed configuration structures
+  NetworkConfiguration network_config_;
+  DaemonConfiguration daemon_config_;
+  SSLConfiguration ssl_config_;
+  PhysicsConfiguration physics_config_;
+  LoggingConfiguration logging_config_;
+  MediaStreamingConfiguration media_streaming_config_;
+
+  // We track configuration validation status
+  bool configuration_valid_ = false;
+  std::vector<std::string> validation_errors_;
+  std::vector<std::string> validation_warnings_;
 
 public:
-    /**
-     * We construct configuration manager with specified config file path
-     * The constructor validates the config file exists and is readable
-     */
-    explicit ConfigurationManager(const std::string& config_file_path = "");
-    
-    /**
-     * We provide destructor for proper cleanup of resources
-     */
-    ~ConfigurationManager() = default;
-    
-    // We prevent copying to ensure single configuration instance
-    ConfigurationManager(const ConfigurationManager&) = delete;
-    ConfigurationManager& operator=(const ConfigurationManager&) = delete;
-    
-    /**
-     * We load configuration from file with comprehensive error handling
-     * This method parses the configuration file and validates all parameters
-     */
-    bool loadConfiguration();
-    
-    /**
-     * We reload configuration unconditionally from the current file
-     * This allows manual refresh of configuration without checking modification time
-     */
-    bool reloadConfiguration();
+  /**
+   * We construct configuration manager with specified config file path
+   * The constructor validates the config file exists and is readable
+   */
+  explicit ConfigurationManager(const std::string &config_file_path = "");
 
-    /**
-     * We reload configuration if file has been modified
-     * This enables runtime configuration updates without daemon restart
-     */
-    bool reloadIfModified();
-    
-    /**
-     * We validate all configuration parameters against constraints
-     * This method checks physics parameters, network settings, and SSL certificates
-     */
-    bool validateConfiguration();
-    
-    /**
-     * We provide access to configuration structures for different subsystems
-     * These methods return const references to prevent unauthorized modification
-     */
-    const NetworkConfiguration& getNetworkConfig() const;
-    const DaemonConfiguration& getDaemonConfig() const;
-    const SSLConfiguration& getSSLConfig() const;
-    const PhysicsConfiguration& getPhysicsConfig() const;
-    const LoggingConfiguration& getLoggingConfig() const;
-    const MediaStreamingConfiguration& getMediaStreamingConfig() const;
-    
-    /**
-     * We provide methods to update specific configuration categories
-     * These methods validate changes before applying them
-     */
-    bool updateNetworkConfig(const NetworkConfiguration& new_config);
-    bool updatePhysicsConfig(const PhysicsConfiguration& new_config);
-    bool updateLoggingConfig(const LoggingConfiguration& new_config);
-    
-    /**
-     * We provide configuration status and diagnostic information
-     * These methods help with debugging and monitoring configuration health
-     */
-    bool isConfigurationValid() const { return configuration_valid_; }
-    const std::vector<std::string>& getValidationErrors() const { return validation_errors_; }
-    const std::vector<std::string>& getValidationWarnings() const { return validation_warnings_; }
-    
-    /**
-     * We provide methods for environment variable override processing
-     * This supports the hybrid configuration strategy outlined in architecture
-     */
-    void processEnvironmentOverrides();
-    std::string getEnvironmentVariable(const std::string& key, const std::string& default_value = "") const;
-    
-    /**
-     * We provide configuration serialization for debugging and API responses
-     * These methods generate JSON representations of configuration state
-     */
-    std::string toJSON() const;
-    std::string getConfigurationSummary() const;
-    
-    /**
-     * We provide SSL certificate validation and management
-     * These methods check certificate validity and handle automatic reloading
-     */
-    bool validateSSLCertificates();
-    bool areSSLCertificatesValid() const;
-    std::chrono::system_clock::time_point getCertificateExpiry() const;
-    
-    /**
-     * We provide configuration file monitoring for automatic reloading
-     * This enables runtime configuration updates in production environments
-     */
-    void enableAutoReload(bool enable = true) { auto_reload_enabled_ = enable; }
-    bool isAutoReloadEnabled() const { return auto_reload_enabled_; }
+  /**
+   * We provide destructor for proper cleanup of resources
+   */
+  ~ConfigurationManager() = default;
+
+  // We prevent copying to ensure single configuration instance
+  ConfigurationManager(const ConfigurationManager &) = delete;
+  ConfigurationManager &operator=(const ConfigurationManager &) = delete;
+
+  /**
+   * We load configuration from file with comprehensive error handling
+   * This method parses the configuration file and validates all parameters
+   */
+  bool loadConfiguration();
+
+  /**
+   * We reload configuration unconditionally from the current file
+   * This allows manual refresh of configuration without checking modification
+   * time
+   */
+  bool reloadConfiguration();
+
+  /**
+   * We reload configuration if file has been modified
+   * This enables runtime configuration updates without daemon restart
+   */
+  bool reloadIfModified();
+
+  /**
+   * We validate all configuration parameters against constraints
+   * This method checks physics parameters, network settings, and SSL
+   * certificates
+   */
+  bool validateConfiguration();
+
+  /**
+   * We provide access to configuration structures for different subsystems
+   * These methods return const references to prevent unauthorized modification
+   */
+  const NetworkConfiguration &getNetworkConfig() const;
+  const DaemonConfiguration &getDaemonConfig() const;
+  const SSLConfiguration &getSSLConfig() const;
+  const PhysicsConfiguration &getPhysicsConfig() const;
+  const LoggingConfiguration &getLoggingConfig() const;
+  const MediaStreamingConfiguration &getMediaStreamingConfig() const;
+
+  /**
+   * We provide methods to update specific configuration categories
+   * These methods validate changes before applying them
+   */
+  bool updateNetworkConfig(const NetworkConfiguration &new_config);
+  bool updatePhysicsConfig(const PhysicsConfiguration &new_config);
+  bool updateLoggingConfig(const LoggingConfiguration &new_config);
+
+  /**
+   * We provide configuration status and diagnostic information
+   * These methods help with debugging and monitoring configuration health
+   */
+  bool isConfigurationValid() const { return configuration_valid_; }
+  const std::vector<std::string> &getValidationErrors() const {
+    return validation_errors_;
+  }
+  const std::vector<std::string> &getValidationWarnings() const {
+    return validation_warnings_;
+  }
+
+  /**
+   * We provide methods for environment variable override processing
+   * This supports the hybrid configuration strategy outlined in architecture
+   */
+  void processEnvironmentOverrides();
+  std::string
+  getEnvironmentVariable(const std::string &key,
+                         const std::string &default_value = "") const;
+
+  /**
+   * We provide configuration serialization for debugging and API responses
+   * These methods generate JSON representations of configuration state
+   */
+  std::string toJSON() const;
+  std::string getConfigurationSummary() const;
+
+  /**
+   * We provide SSL certificate validation and management
+   * These methods check certificate validity and handle automatic reloading
+   */
+  bool validateSSLCertificates();
+  bool areSSLCertificatesValid() const;
+  std::chrono::system_clock::time_point getCertificateExpiry() const;
+
+  /**
+   * We provide configuration file monitoring for automatic reloading
+   * This enables runtime configuration updates in production environments
+   */
+  void enableAutoReload(bool enable = true) { auto_reload_enabled_ = enable; }
+  bool isAutoReloadEnabled() const { return auto_reload_enabled_; }
 
 private:
-    /**
-     * We implement internal methods for configuration processing
-     * These methods handle the detailed parsing and validation logic
-     */
-    bool parseConfigurationFile();
-    bool parseNetworkConfiguration();
-    bool parseDaemonConfiguration();
-    bool parseSSLConfiguration();
-    bool parsePhysicsConfiguration();
-    bool parseLoggingConfiguration();
-    bool parseMediaStreamingConfiguration();
-    
-    /**
-     * We implement configuration value parsing and type conversion
-     * These methods handle string-to-type conversion with error checking
-     */
-    std::string getConfigValue(const std::string& key, const std::string& default_value = "") const;
-    int getConfigInt(const std::string& key, int default_value = 0) const;
-    double getConfigDouble(const std::string& key, double default_value = 0.0) const;
-    bool getConfigBool(const std::string& key, bool default_value = false) const;
-    std::vector<std::string> getConfigStringList(const std::string& key) const;
-    
-    /**
-     * We implement validation methods for different configuration categories
-     * These methods check parameter ranges and theoretical constraints
-     */
-    bool validateNetworkConfiguration();
-    bool validateDaemonConfiguration();
-    bool validateSSLConfiguration();
-    bool validatePhysicsConfiguration();
-    bool validateLoggingConfiguration();
-    bool validateMediaStreamingConfiguration();
-    
-    /**
-     * We implement file system utility methods for configuration management
-     * These methods handle file existence, permissions, and modification tracking
-     */
-    bool fileExists(const std::string& path) const;
-    bool isFileReadable(const std::string& path) const;
-    std::chrono::system_clock::time_point getFileModificationTime(const std::string& path) const;
-    bool createDirectoryIfNeeded(const std::string& path) const;
-    
-    /**
-     * We implement SSL certificate utility methods
-     * These methods validate certificate files and extract expiration information
-     */
-    bool validateCertificateFile(const std::string& cert_path);
-    bool validatePrivateKeyFile(const std::string& key_path);
-    bool validateCAFile(const std::string& ca_path);
-    std::chrono::system_clock::time_point extractCertificateExpiry(const std::string& cert_path);
-    
-    /**
-     * We implement physics parameter validation against theoretical constraints
-     * These methods ensure simulation parameters are within realistic ranges
-     */
-    bool validatePhysicsParameterRanges();
-    bool validateConservationLawSettings();
-    bool validateEnergyFieldLimits();
-    
-    /**
-     * We implement error and warning management for configuration diagnostics
-     * These methods track validation issues for debugging and monitoring
-     */
-    void clearValidationMessages();
-    void addValidationError(const std::string& error);
-    void addValidationWarning(const std::string& warning);
+  /**
+   * We implement internal methods for configuration processing
+   * These methods handle the detailed parsing and validation logic
+   */
+  bool parseConfigurationFile();
+  bool parseNetworkConfiguration();
+  bool parseDaemonConfiguration();
+  bool parseSSLConfiguration();
+  bool parsePhysicsConfiguration();
+  bool parseLoggingConfiguration();
+  bool parseMediaStreamingConfiguration();
+
+  /**
+   * We implement configuration value parsing and type conversion
+   * These methods handle string-to-type conversion with error checking
+   */
+  std::string getConfigValue(const std::string &key,
+                             const std::string &default_value = "") const;
+  int getConfigInt(const std::string &key, int default_value = 0) const;
+  double getConfigDouble(const std::string &key,
+                         double default_value = 0.0) const;
+  bool getConfigBool(const std::string &key, bool default_value = false) const;
+  std::vector<std::string> getConfigStringList(const std::string &key) const;
+
+  /**
+   * We implement validation methods for different configuration categories
+   * These methods check parameter ranges and theoretical constraints
+   */
+  bool validateNetworkConfiguration();
+  bool validateDaemonConfiguration();
+  bool validateSSLConfiguration();
+  bool validatePhysicsConfiguration();
+  bool validateLoggingConfiguration();
+  bool validateMediaStreamingConfiguration();
+
+  /**
+   * We implement file system utility methods for configuration management
+   * These methods handle file existence, permissions, and modification tracking
+   */
+  bool fileExists(const std::string &path) const;
+  bool isFileReadable(const std::string &path) const;
+  std::chrono::system_clock::time_point
+  getFileModificationTime(const std::string &path) const;
+  bool createDirectoryIfNeeded(const std::string &path) const;
+
+  /**
+   * We implement SSL certificate utility methods
+   * These methods validate certificate files and extract expiration information
+   */
+  bool validateCertificateFile(const std::string &cert_path);
+  bool validatePrivateKeyFile(const std::string &key_path);
+  std::chrono::system_clock::time_point
+  extractCertificateExpiry(const std::string &cert_path);
+
+  /**
+   * We implement physics parameter validation against theoretical constraints
+   * These methods ensure simulation parameters are within realistic ranges
+   */
+  bool validatePhysicsParameterRanges();
+  bool validateConservationLawSettings();
+  bool validateEnergyFieldLimits();
+
+  /**
+   * We implement error and warning management for configuration diagnostics
+   * These methods track validation issues for debugging and monitoring
+   */
+  void clearValidationMessages();
+  void addValidationError(const std::string &error);
+  void addValidationWarning(const std::string &warning);
 };
 
 /**
- * We provide utility functions for configuration management across the application
- * These functions support common configuration operations and debugging
+ * We provide utility functions for configuration management across the
+ * application These functions support common configuration operations and
+ * debugging
  */
 namespace ConfigurationUtils {
-    /**
-     * We provide default configuration file path detection
-     * This function searches standard locations for configuration files
-     */
-    std::string findDefaultConfigFile();
-    
-    /**
-     * We provide configuration template generation
-     * This function creates example configuration files with documentation
-     */
-    bool generateConfigurationTemplate(const std::string& output_path);
-    
-    /**
-     * We provide configuration validation utilities
-     * These functions validate specific configuration aspects independently
-     */
-    bool validateIPAddress(const std::string& ip_address);
-    bool validatePortNumber(int port);
-    bool validateFilePath(const std::string& path, bool must_exist = true);
-    bool validateDirectoryPath(const std::string& path, bool create_if_missing = false);
-    
-    /**
-     * We provide SSL certificate utility functions
-     * These functions handle certificate operations across different platforms
-     */
-    bool isCertificateFileValid(const std::string& cert_path);
-    bool isPrivateKeyFileValid(const std::string& key_path);
-    std::string generateSelfSignedCertificate(const std::string& hostname);
-    
-    /**
-     * We provide physics parameter validation utilities
-     * These functions check parameters against theoretical physics constraints
-     */
-    bool isValidNuclearMass(double mass);
-    bool isValidExcitationEnergy(double energy);
-    bool isValidEnergyField(double energy);
-    bool areConservationLawTolerancesRealistic(double tolerance);
-}
+/**
+ * We provide default configuration file path detection
+ * This function searches standard locations for configuration files
+ */
+std::string findDefaultConfigFile();
 
+/**
+ * We provide configuration template generation
+ * This function creates example configuration files with documentation
+ */
+bool generateConfigurationTemplate(const std::string &output_path);
+
+/**
+ * We provide configuration validation utilities
+ * These functions validate specific configuration aspects independently
+ */
+bool validateIPAddress(const std::string &ip_address);
+bool validatePortNumber(int port);
+bool validateFilePath(const std::string &path, bool must_exist = true);
+bool validateDirectoryPath(const std::string &path,
+                           bool create_if_missing = false);
+
+/**
+ * We provide SSL certificate utility functions
+ * These functions handle certificate operations across different platforms
+ */
+bool isCertificateFileValid(const std::string &cert_path);
+bool isPrivateKeyFileValid(const std::string &key_path);
+std::string generateSelfSignedCertificate(const std::string &hostname);
+
+/**
+ * We provide physics parameter validation utilities
+ * These functions check parameters against theoretical physics constraints
+ */
+bool isValidNuclearMass(double mass);
+bool isValidExcitationEnergy(double energy);
+bool isValidEnergyField(double energy);
+bool areConservationLawTolerancesRealistic(double tolerance);
+} // namespace ConfigurationUtils
 
 } // namespace TernaryFission
 

--- a/src/cpp/config.ternary.fission.server.cpp
+++ b/src/cpp/config.ternary.fission.server.cpp
@@ -2,21 +2,24 @@
  * File: src/cpp/config.ternary.fission.server.cpp
  * Author: bthlops (David StJ)
  * Date: January 31, 2025
- * Title: Configuration Management System Implementation for Ternary Fission Daemon Server
- * Purpose: Complete implementation of configuration parsing, validation, and management for daemon operations
- * Reason: Provides centralized configuration management supporting distributed daemon architecture
+ * Title: Configuration Management System Implementation for Ternary Fission
+ * Daemon Server Purpose: Complete implementation of configuration parsing,
+ * validation, and management for daemon operations Reason: Provides centralized
+ * configuration management supporting distributed daemon architecture
  *
  * Change Log:
- * 2025-01-31: Initial implementation for distributed daemon architecture Phase 1
- *             Added complete configuration file parsing with inline comment support
+ * 2025-01-31: Initial implementation for distributed daemon architecture Phase
+ * 1 Added complete configuration file parsing with inline comment support
  *             Implemented SSL certificate validation and automatic detection
- *             Added physics parameter validation against theoretical constraints
- *             Integrated environment variable override processing
- *             Added comprehensive error handling and validation reporting
+ *             Added physics parameter validation against theoretical
+ * constraints Integrated environment variable override processing Added
+ * comprehensive error handling and validation reporting
  *
  * Carry-over Context:
- * - This implementation supports the HTTP daemon functionality outlined in ARCH.md
- * - Configuration format matches Go server for consistency across distributed services
+ * - This implementation supports the HTTP daemon functionality outlined in
+ * ARCH.md
+ * - Configuration format matches Go server for consistency across distributed
+ * services
  * - SSL certificate management enables HTTPS daemon operation
  * - Physics parameter validation ensures theoretical constraints are maintained
  * - Environment overrides support operational flexibility in production
@@ -25,45 +28,48 @@
 
 #include "config.ternary.fission.server.h"
 #include "physics.constants.definitions.h"
-#include <iostream>
-#include <sstream>
-#include <fstream>
 #include <algorithm>
+#include <arpa/inet.h>
 #include <cctype>
 #include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <sstream>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <openssl/x509.h>
-#include <openssl/pem.h>
-#include <openssl/err.h>
-#include <arpa/inet.h>
 
 namespace TernaryFission {
 
 /**
  * We construct the configuration manager with proper initialization
- * The constructor sets up all default values and prepares for configuration loading
+ * The constructor sets up all default values and prepares for configuration
+ * loading
  */
-ConfigurationManager::ConfigurationManager(const std::string& config_file_path)
-    : config_file_path_(config_file_path.empty() ? ConfigurationUtils::findDefaultConfigFile() : config_file_path),
+ConfigurationManager::ConfigurationManager(const std::string &config_file_path)
+    : config_file_path_(config_file_path.empty()
+                            ? ConfigurationUtils::findDefaultConfigFile()
+                            : config_file_path),
       last_modified_(std::chrono::system_clock::time_point::min()),
       configuration_valid_(false) {
-    
-    // We initialize default configuration values
-    network_config_ = NetworkConfiguration();
-    daemon_config_ = DaemonConfiguration();
-    ssl_config_ = SSLConfiguration();
-    physics_config_ = PhysicsConfiguration();
-    logging_config_ = LoggingConfiguration();
-    media_streaming_config_ = MediaStreamingConfiguration();
-    
-    // We process environment variable overrides first
-    processEnvironmentOverrides();
-    
-    // We attempt initial configuration loading if file exists
-    if (!config_file_path_.empty() && fileExists(config_file_path_)) {
-        loadConfiguration();
-    }
+
+  // We initialize default configuration values
+  network_config_ = NetworkConfiguration();
+  daemon_config_ = DaemonConfiguration();
+  ssl_config_ = SSLConfiguration();
+  physics_config_ = PhysicsConfiguration();
+  logging_config_ = LoggingConfiguration();
+  media_streaming_config_ = MediaStreamingConfiguration();
+
+  // We process environment variable overrides first
+  processEnvironmentOverrides();
+
+  // We attempt initial configuration loading if file exists
+  if (!config_file_path_.empty() && fileExists(config_file_path_)) {
+    loadConfiguration();
+  }
 }
 
 /**
@@ -71,65 +77,68 @@ ConfigurationManager::ConfigurationManager(const std::string& config_file_path)
  * This method parses the configuration file and validates all parameters
  */
 bool ConfigurationManager::loadConfiguration() {
-    std::lock_guard<std::mutex> lock(config_mutex_);
-    
-    clearValidationMessages();
-    
-    if (config_file_path_.empty()) {
-        addValidationError("No configuration file path specified");
-        return false;
-    }
-    
-    if (!fileExists(config_file_path_)) {
-        addValidationError("Configuration file does not exist: " + config_file_path_);
-        return false;
-    }
-    
-    if (!isFileReadable(config_file_path_)) {
-        addValidationError("Configuration file is not readable: " + config_file_path_);
-        return false;
-    }
-    
-    // We track file modification time for reload detection
-    last_modified_ = getFileModificationTime(config_file_path_);
-    
-    // We parse the configuration file
-    if (!parseConfigurationFile()) {
-        addValidationError("Failed to parse configuration file: " + config_file_path_);
-        return false;
-    }
-    
-    // We validate all configuration sections
-    bool validation_success = validateConfiguration();
-    configuration_valid_ = validation_success;
-    
-    return validation_success;
+  std::lock_guard<std::mutex> lock(config_mutex_);
+
+  clearValidationMessages();
+
+  if (config_file_path_.empty()) {
+    addValidationError("No configuration file path specified");
+    return false;
+  }
+
+  if (!fileExists(config_file_path_)) {
+    addValidationError("Configuration file does not exist: " +
+                       config_file_path_);
+    return false;
+  }
+
+  if (!isFileReadable(config_file_path_)) {
+    addValidationError("Configuration file is not readable: " +
+                       config_file_path_);
+    return false;
+  }
+
+  // We track file modification time for reload detection
+  last_modified_ = getFileModificationTime(config_file_path_);
+
+  // We parse the configuration file
+  if (!parseConfigurationFile()) {
+    addValidationError("Failed to parse configuration file: " +
+                       config_file_path_);
+    return false;
+  }
+
+  // We validate all configuration sections
+  bool validation_success = validateConfiguration();
+  configuration_valid_ = validation_success;
+
+  return validation_success;
 }
 
 /**
  * We reload configuration unconditionally from the current file
- * This allows manual refresh of configuration without checking modification time
+ * This allows manual refresh of configuration without checking modification
+ * time
  */
-bool ConfigurationManager::reloadConfiguration() {
-    return loadConfiguration();
-}
+bool ConfigurationManager::reloadConfiguration() { return loadConfiguration(); }
 
 /**
  * We reload configuration if file has been modified
  * This enables runtime configuration updates without daemon restart
  */
 bool ConfigurationManager::reloadIfModified() {
-    if (!auto_reload_enabled_ || config_file_path_.empty()) {
-        return false;
-    }
-    
-    auto current_modified = getFileModificationTime(config_file_path_);
-    if (current_modified > last_modified_) {
-        std::cout << "Configuration file modified, reloading: " << config_file_path_ << std::endl;
-        return loadConfiguration();
-    }
-    
+  if (!auto_reload_enabled_ || config_file_path_.empty()) {
     return false;
+  }
+
+  auto current_modified = getFileModificationTime(config_file_path_);
+  if (current_modified > last_modified_) {
+    std::cout << "Configuration file modified, reloading: " << config_file_path_
+              << std::endl;
+    return loadConfiguration();
+  }
+
+  return false;
 }
 
 /**
@@ -137,17 +146,23 @@ bool ConfigurationManager::reloadIfModified() {
  * This method performs comprehensive validation of all configuration sections
  */
 bool ConfigurationManager::validateConfiguration() {
-    bool all_valid = true;
-    
-    // We validate each configuration section independently
-    if (!validateNetworkConfiguration()) all_valid = false;
-    if (!validateDaemonConfiguration()) all_valid = false;
-    if (!validateSSLConfiguration()) all_valid = false;
-    if (!validatePhysicsConfiguration()) all_valid = false;
-    if (!validateLoggingConfiguration()) all_valid = false;
-    if (!validateMediaStreamingConfiguration()) all_valid = false;
-    
-    return all_valid;
+  bool all_valid = true;
+
+  // We validate each configuration section independently
+  if (!validateNetworkConfiguration())
+    all_valid = false;
+  if (!validateDaemonConfiguration())
+    all_valid = false;
+  if (!validateSSLConfiguration())
+    all_valid = false;
+  if (!validatePhysicsConfiguration())
+    all_valid = false;
+  if (!validateLoggingConfiguration())
+    all_valid = false;
+  if (!validateMediaStreamingConfiguration())
+    all_valid = false;
+
+  return all_valid;
 }
 
 /**
@@ -155,71 +170,78 @@ bool ConfigurationManager::validateConfiguration() {
  * This method handles inline comments, whitespace, and type conversion
  */
 bool ConfigurationManager::parseConfigurationFile() {
-    std::ifstream file(config_file_path_);
-    if (!file.is_open()) {
-        return false;
+  std::ifstream file(config_file_path_);
+  if (!file.is_open()) {
+    return false;
+  }
+
+  raw_config_.clear();
+  std::string line;
+  int line_number = 0;
+
+  while (std::getline(file, line)) {
+    line_number++;
+
+    // We trim whitespace from the line
+    line.erase(0, line.find_first_not_of(" \t\r\n"));
+    line.erase(line.find_last_not_of(" \t\r\n") + 1);
+
+    // We skip empty lines and comments
+    if (line.empty() || line[0] == '#') {
+      continue;
     }
-    
-    raw_config_.clear();
-    std::string line;
-    int line_number = 0;
-    
-    while (std::getline(file, line)) {
-        line_number++;
-        
-        // We trim whitespace from the line
-        line.erase(0, line.find_first_not_of(" \t\r\n"));
-        line.erase(line.find_last_not_of(" \t\r\n") + 1);
-        
-        // We skip empty lines and comments
-        if (line.empty() || line[0] == '#') {
-            continue;
-        }
-        
-        // We parse key=value pairs
-        size_t equals_pos = line.find('=');
-        if (equals_pos == std::string::npos) {
-            addValidationWarning("Invalid configuration line " + std::to_string(line_number) + ": " + line);
-            continue;
-        }
-        
-        std::string key = line.substr(0, equals_pos);
-        std::string value = line.substr(equals_pos + 1);
-        
-        // We trim whitespace from key and value
-        key.erase(0, key.find_first_not_of(" \t"));
-        key.erase(key.find_last_not_of(" \t") + 1);
-        value.erase(0, value.find_first_not_of(" \t"));
-        value.erase(value.find_last_not_of(" \t") + 1);
-        
-        // We remove inline comments from value
-        size_t comment_pos = value.find('#');
-        if (comment_pos != std::string::npos) {
-            value = value.substr(0, comment_pos);
-            value.erase(value.find_last_not_of(" \t") + 1);
-        }
-        
-        // We remove quotes from value if present
-        if (value.length() >= 2 && 
-            ((value.front() == '"' && value.back() == '"') ||
-             (value.front() == '\'' && value.back() == '\''))) {
-            value = value.substr(1, value.length() - 2);
-        }
-        
-        raw_config_[key] = value;
+
+    // We parse key=value pairs
+    size_t equals_pos = line.find('=');
+    if (equals_pos == std::string::npos) {
+      addValidationWarning("Invalid configuration line " +
+                           std::to_string(line_number) + ": " + line);
+      continue;
     }
-    
-    file.close();
-    
-    // We parse individual configuration sections
-    if (!parseNetworkConfiguration()) return false;
-    if (!parseDaemonConfiguration()) return false;
-    if (!parseSSLConfiguration()) return false;
-    if (!parsePhysicsConfiguration()) return false;
-    if (!parseLoggingConfiguration()) return false;
-    if (!parseMediaStreamingConfiguration()) return false;
-    
-    return true;
+
+    std::string key = line.substr(0, equals_pos);
+    std::string value = line.substr(equals_pos + 1);
+
+    // We trim whitespace from key and value
+    key.erase(0, key.find_first_not_of(" \t"));
+    key.erase(key.find_last_not_of(" \t") + 1);
+    value.erase(0, value.find_first_not_of(" \t"));
+    value.erase(value.find_last_not_of(" \t") + 1);
+
+    // We remove inline comments from value
+    size_t comment_pos = value.find('#');
+    if (comment_pos != std::string::npos) {
+      value = value.substr(0, comment_pos);
+      value.erase(value.find_last_not_of(" \t") + 1);
+    }
+
+    // We remove quotes from value if present
+    if (value.length() >= 2 &&
+        ((value.front() == '"' && value.back() == '"') ||
+         (value.front() == '\'' && value.back() == '\''))) {
+      value = value.substr(1, value.length() - 2);
+    }
+
+    raw_config_[key] = value;
+  }
+
+  file.close();
+
+  // We parse individual configuration sections
+  if (!parseNetworkConfiguration())
+    return false;
+  if (!parseDaemonConfiguration())
+    return false;
+  if (!parseSSLConfiguration())
+    return false;
+  if (!parsePhysicsConfiguration())
+    return false;
+  if (!parseLoggingConfiguration())
+    return false;
+  if (!parseMediaStreamingConfiguration())
+    return false;
+
+  return true;
 }
 
 /**
@@ -227,25 +249,25 @@ bool ConfigurationManager::parseConfigurationFile() {
  * This method processes all network-related configuration parameters
  */
 bool ConfigurationManager::parseNetworkConfiguration() {
-    network_config_.bind_ip = getConfigValue("bind_ip", "127.0.0.1");
-    network_config_.bind_port = getConfigInt("bind_port", 8333);
-    network_config_.enable_ssl = getConfigBool("enable_ssl", false);
-    network_config_.ssl_cert_path = getConfigValue("ssl_cert_path", "");
-    network_config_.ssl_key_path = getConfigValue("ssl_key_path", "");
-    network_config_.ssl_ca_path = getConfigValue("ssl_ca_path", "");
-    network_config_.max_connections = getConfigInt("max_connections", 1000);
-    network_config_.connection_timeout = getConfigInt("connection_timeout", 30);
-    network_config_.enable_cors = getConfigBool("enable_cors", true);
-    network_config_.request_size_limit = getConfigInt("request_size_limit", 10485760);
-    network_config_.web_root = getConfigValue("web_root", "");
+  network_config_.bind_ip = getConfigValue("bind_ip", "127.0.0.1");
+  network_config_.bind_port = getConfigInt("bind_port", 8333);
+  network_config_.enable_ssl = getConfigBool("enable_ssl", false);
+  network_config_.ssl_cert_chain = getConfigValue("ssl_cert_chain", "");
+  network_config_.ssl_private_key = getConfigValue("ssl_private_key", "");
+  network_config_.max_connections = getConfigInt("max_connections", 1000);
+  network_config_.connection_timeout = getConfigInt("connection_timeout", 30);
+  network_config_.enable_cors = getConfigBool("enable_cors", true);
+  network_config_.request_size_limit =
+      getConfigInt("request_size_limit", 10485760);
+  network_config_.web_root = getConfigValue("web_root", "");
 
-    // We parse CORS origins list
-    std::string cors_origins_str = getConfigValue("cors_origins", "*");
-    if (cors_origins_str != "*") {
-        network_config_.cors_origins = getConfigStringList("cors_origins");
-    }
-    
-    return true;
+  // We parse CORS origins list
+  std::string cors_origins_str = getConfigValue("cors_origins", "*");
+  if (cors_origins_str != "*") {
+    network_config_.cors_origins = getConfigStringList("cors_origins");
+  }
+
+  return true;
 }
 
 /**
@@ -253,38 +275,42 @@ bool ConfigurationManager::parseNetworkConfiguration() {
  * This method processes all daemon process management parameters
  */
 bool ConfigurationManager::parseDaemonConfiguration() {
-    daemon_config_.daemon_mode = getConfigBool("daemon_mode", false);
-    daemon_config_.pid_file_path = getConfigValue("pid_file_path", "/tmp/ternary-fission-daemon.pid");
-    daemon_config_.working_directory = getConfigValue("working_directory", "/");
-    daemon_config_.user_name = getConfigValue("daemon_user", "");
-    daemon_config_.group_name = getConfigValue("daemon_group", "");
-    daemon_config_.umask_value = getConfigInt("daemon_umask", 022);
-    daemon_config_.create_pid_file = getConfigBool("create_pid_file", true);
-    daemon_config_.shutdown_timeout = getConfigInt("shutdown_timeout", 30);
-    
-    return true;
+  daemon_config_.daemon_mode = getConfigBool("daemon_mode", false);
+  daemon_config_.pid_file_path =
+      getConfigValue("pid_file_path", "/tmp/ternary-fission-daemon.pid");
+  daemon_config_.working_directory = getConfigValue("working_directory", "/");
+  daemon_config_.user_name = getConfigValue("daemon_user", "");
+  daemon_config_.group_name = getConfigValue("daemon_group", "");
+  daemon_config_.umask_value = getConfigInt("daemon_umask", 022);
+  daemon_config_.create_pid_file = getConfigBool("create_pid_file", true);
+  daemon_config_.shutdown_timeout = getConfigInt("shutdown_timeout", 30);
+
+  return true;
 }
 
 /**
  * We parse SSL configuration section with certificate validation
- * This method processes all SSL/TLS related parameters and validates certificates
+ * This method processes all SSL/TLS related parameters and validates
+ * certificates
  */
 bool ConfigurationManager::parseSSLConfiguration() {
-    ssl_config_.ssl_enabled = network_config_.enable_ssl;
-    ssl_config_.certificate_file = network_config_.ssl_cert_path;
-    ssl_config_.private_key_file = network_config_.ssl_key_path;
-    ssl_config_.ca_certificate_file = network_config_.ssl_ca_path;
-    ssl_config_.cipher_suite = getConfigValue("ssl_cipher_suite", "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256");
-    ssl_config_.verify_client_certificates = getConfigBool("ssl_verify_client", false);
-    ssl_config_.ssl_protocol_version = getConfigInt("ssl_protocol_version", 0);
-    ssl_config_.auto_reload_certificates = getConfigBool("ssl_auto_reload", true);
-    
-    // We validate SSL certificates if SSL is enabled
-    if (ssl_config_.ssl_enabled) {
-        validateSSLCertificates();
-    }
-    
-    return true;
+  ssl_config_.ssl_enabled = network_config_.enable_ssl;
+  ssl_config_.certificate_file = network_config_.ssl_cert_chain;
+  ssl_config_.private_key_file = network_config_.ssl_private_key;
+  ssl_config_.cipher_suite =
+      getConfigValue("ssl_cipher_suite",
+                     "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256");
+  ssl_config_.verify_client_certificates =
+      getConfigBool("ssl_verify_client", false);
+  ssl_config_.ssl_protocol_version = getConfigInt("ssl_protocol_version", 0);
+  ssl_config_.auto_reload_certificates = getConfigBool("ssl_auto_reload", true);
+
+  // We validate SSL certificates if SSL is enabled
+  if (ssl_config_.ssl_enabled) {
+    validateSSLCertificates();
+  }
+
+  return true;
 }
 
 /**
@@ -292,17 +318,22 @@ bool ConfigurationManager::parseSSLConfiguration() {
  * This method processes all physics simulation parameters
  */
 bool ConfigurationManager::parsePhysicsConfiguration() {
-    physics_config_.default_parent_mass = getConfigDouble("parent_mass", 235.0);
-    physics_config_.default_excitation_energy = getConfigDouble("excitation_energy", 6.5);
-    physics_config_.max_energy_field = getConfigDouble("max_energy_field", 1000.0);
-    physics_config_.min_energy_field = getConfigDouble("min_energy_field", 0.1);
-    physics_config_.default_thread_count = getConfigInt("num_threads", 0);
-    physics_config_.conservation_tolerance = getConfigDouble("conservation_tolerance", 1e-6);
-    physics_config_.enable_conservation_checks = getConfigBool("enable_conservation_checks", true);
-    physics_config_.events_per_second = getConfigDouble("events_per_second", 5.0);
-    physics_config_.max_events_per_request = getConfigInt("max_events_per_request", 100000);
-    
-    return true;
+  physics_config_.default_parent_mass = getConfigDouble("parent_mass", 235.0);
+  physics_config_.default_excitation_energy =
+      getConfigDouble("excitation_energy", 6.5);
+  physics_config_.max_energy_field =
+      getConfigDouble("max_energy_field", 1000.0);
+  physics_config_.min_energy_field = getConfigDouble("min_energy_field", 0.1);
+  physics_config_.default_thread_count = getConfigInt("num_threads", 0);
+  physics_config_.conservation_tolerance =
+      getConfigDouble("conservation_tolerance", 1e-6);
+  physics_config_.enable_conservation_checks =
+      getConfigBool("enable_conservation_checks", true);
+  physics_config_.events_per_second = getConfigDouble("events_per_second", 5.0);
+  physics_config_.max_events_per_request =
+      getConfigInt("max_events_per_request", 100000);
+
+  return true;
 }
 
 /**
@@ -310,26 +341,35 @@ bool ConfigurationManager::parsePhysicsConfiguration() {
  * This method processes all logging and output parameters
  */
 bool ConfigurationManager::parseLoggingConfiguration() {
-    logging_config_.log_level = getConfigValue("log_level", "info");
-    logging_config_.access_log_path = getConfigValue("access_log_path", "logs/daemon-access.log");
-    logging_config_.error_log_path = getConfigValue("error_log_path", "logs/daemon-error.log");
-    logging_config_.debug_log_path = getConfigValue("debug_log_path", "logs/daemon-debug.log");
-    logging_config_.enable_console_logging = getConfigBool("enable_console_logging", true);
-    logging_config_.enable_file_logging = getConfigBool("enable_file_logging", true);
-    logging_config_.max_log_file_size = getConfigInt("max_log_file_size", 104857600);
-    logging_config_.log_rotation_count = getConfigInt("log_rotation_count", 10);
-    logging_config_.enable_json_logging = getConfigBool("enable_json_logging", false);
-    logging_config_.verbose_output = getConfigBool("verbose_output", false);
-    logging_config_.log_timestamp_format = getConfigValue("log_timestamp_format", "%Y-%m-%d %H:%M:%S");
+  logging_config_.log_level = getConfigValue("log_level", "info");
+  logging_config_.access_log_path =
+      getConfigValue("access_log_path", "logs/daemon-access.log");
+  logging_config_.error_log_path =
+      getConfigValue("error_log_path", "logs/daemon-error.log");
+  logging_config_.debug_log_path =
+      getConfigValue("debug_log_path", "logs/daemon-debug.log");
+  logging_config_.enable_console_logging =
+      getConfigBool("enable_console_logging", true);
+  logging_config_.enable_file_logging =
+      getConfigBool("enable_file_logging", true);
+  logging_config_.max_log_file_size =
+      getConfigInt("max_log_file_size", 104857600);
+  logging_config_.log_rotation_count = getConfigInt("log_rotation_count", 10);
+  logging_config_.enable_json_logging =
+      getConfigBool("enable_json_logging", false);
+  logging_config_.verbose_output = getConfigBool("verbose_output", false);
+  logging_config_.log_timestamp_format =
+      getConfigValue("log_timestamp_format", "%Y-%m-%d %H:%M:%S");
 
-    return true;
+  return true;
 }
 
 bool ConfigurationManager::parseMediaStreamingConfiguration() {
-    media_streaming_config_.media_streaming_enabled = getConfigBool("media_streaming_enabled", false);
-    media_streaming_config_.media_root = getConfigValue("media_root", "");
-    media_streaming_config_.icecast_mount = getConfigValue("icecast_mount", "");
-    return true;
+  media_streaming_config_.media_streaming_enabled =
+      getConfigBool("media_streaming_enabled", false);
+  media_streaming_config_.media_root = getConfigValue("media_root", "");
+  media_streaming_config_.icecast_mount = getConfigValue("icecast_mount", "");
+  return true;
 }
 
 /**
@@ -337,45 +377,53 @@ bool ConfigurationManager::parseMediaStreamingConfiguration() {
  * This method checks network settings for validity and security
  */
 bool ConfigurationManager::validateNetworkConfiguration() {
-    bool valid = true;
-    
-    // We validate IP address format
-    if (!ConfigurationUtils::validateIPAddress(network_config_.bind_ip)) {
-        addValidationError("Invalid bind IP address: " + network_config_.bind_ip);
-        valid = false;
-    }
-    
-    // We validate port number range
-    if (!ConfigurationUtils::validatePortNumber(network_config_.bind_port)) {
-        addValidationError("Invalid bind port: " + std::to_string(network_config_.bind_port));
-        valid = false;
-    }
-    
-    // We validate connection limits
-    if (network_config_.max_connections < 1 || network_config_.max_connections > 65535) {
-        addValidationError("Invalid max_connections: " + std::to_string(network_config_.max_connections));
-        valid = false;
-    }
-    
-    // We validate timeout values
-    if (network_config_.connection_timeout < 1 || network_config_.connection_timeout > 3600) {
-        addValidationError("Invalid connection_timeout: " + std::to_string(network_config_.connection_timeout));
-        valid = false;
-    }
-    
-    // We validate request size limit
-    if (network_config_.request_size_limit < 1024 || network_config_.request_size_limit > 1073741824) {
-        addValidationError("Invalid request_size_limit: " + std::to_string(network_config_.request_size_limit));
-        valid = false;
-    }
+  bool valid = true;
 
-    // We validate web root directory
-    if (!ConfigurationUtils::validateDirectoryPath(network_config_.web_root, false)) {
-        addValidationError("Invalid web_root: " + network_config_.web_root);
-        valid = false;
-    }
+  // We validate IP address format
+  if (!ConfigurationUtils::validateIPAddress(network_config_.bind_ip)) {
+    addValidationError("Invalid bind IP address: " + network_config_.bind_ip);
+    valid = false;
+  }
 
-    return valid;
+  // We validate port number range
+  if (!ConfigurationUtils::validatePortNumber(network_config_.bind_port)) {
+    addValidationError("Invalid bind port: " +
+                       std::to_string(network_config_.bind_port));
+    valid = false;
+  }
+
+  // We validate connection limits
+  if (network_config_.max_connections < 1 ||
+      network_config_.max_connections > 65535) {
+    addValidationError("Invalid max_connections: " +
+                       std::to_string(network_config_.max_connections));
+    valid = false;
+  }
+
+  // We validate timeout values
+  if (network_config_.connection_timeout < 1 ||
+      network_config_.connection_timeout > 3600) {
+    addValidationError("Invalid connection_timeout: " +
+                       std::to_string(network_config_.connection_timeout));
+    valid = false;
+  }
+
+  // We validate request size limit
+  if (network_config_.request_size_limit < 1024 ||
+      network_config_.request_size_limit > 1073741824) {
+    addValidationError("Invalid request_size_limit: " +
+                       std::to_string(network_config_.request_size_limit));
+    valid = false;
+  }
+
+  // We validate web root directory
+  if (!ConfigurationUtils::validateDirectoryPath(network_config_.web_root,
+                                                 false)) {
+    addValidationError("Invalid web_root: " + network_config_.web_root);
+    valid = false;
+  }
+
+  return valid;
 }
 
 /**
@@ -383,36 +431,42 @@ bool ConfigurationManager::validateNetworkConfiguration() {
  * This method checks daemon process management settings
  */
 bool ConfigurationManager::validateDaemonConfiguration() {
-    bool valid = true;
-    
-    // We validate PID file path is writable
-    if (daemon_config_.create_pid_file) {
-        std::string pid_dir = daemon_config_.pid_file_path.substr(0, daemon_config_.pid_file_path.find_last_of('/'));
-        if (!ConfigurationUtils::validateDirectoryPath(pid_dir, true)) {
-            addValidationError("PID file directory not writable: " + pid_dir);
-            valid = false;
-        }
+  bool valid = true;
+
+  // We validate PID file path is writable
+  if (daemon_config_.create_pid_file) {
+    std::string pid_dir = daemon_config_.pid_file_path.substr(
+        0, daemon_config_.pid_file_path.find_last_of('/'));
+    if (!ConfigurationUtils::validateDirectoryPath(pid_dir, true)) {
+      addValidationError("PID file directory not writable: " + pid_dir);
+      valid = false;
     }
-    
-    // We validate working directory exists
-    if (!ConfigurationUtils::validateDirectoryPath(daemon_config_.working_directory, false)) {
-        addValidationError("Working directory does not exist: " + daemon_config_.working_directory);
-        valid = false;
-    }
-    
-    // We validate umask value
-    if (daemon_config_.umask_value < 0 || daemon_config_.umask_value > 0777) {
-        addValidationError("Invalid umask value: " + std::to_string(daemon_config_.umask_value));
-        valid = false;
-    }
-    
-    // We validate shutdown timeout
-    if (daemon_config_.shutdown_timeout < 1 || daemon_config_.shutdown_timeout > 300) {
-        addValidationError("Invalid shutdown_timeout: " + std::to_string(daemon_config_.shutdown_timeout));
-        valid = false;
-    }
-    
-    return valid;
+  }
+
+  // We validate working directory exists
+  if (!ConfigurationUtils::validateDirectoryPath(
+          daemon_config_.working_directory, false)) {
+    addValidationError("Working directory does not exist: " +
+                       daemon_config_.working_directory);
+    valid = false;
+  }
+
+  // We validate umask value
+  if (daemon_config_.umask_value < 0 || daemon_config_.umask_value > 0777) {
+    addValidationError("Invalid umask value: " +
+                       std::to_string(daemon_config_.umask_value));
+    valid = false;
+  }
+
+  // We validate shutdown timeout
+  if (daemon_config_.shutdown_timeout < 1 ||
+      daemon_config_.shutdown_timeout > 300) {
+    addValidationError("Invalid shutdown_timeout: " +
+                       std::to_string(daemon_config_.shutdown_timeout));
+    valid = false;
+  }
+
+  return valid;
 }
 
 /**
@@ -420,45 +474,41 @@ bool ConfigurationManager::validateDaemonConfiguration() {
  * This method performs comprehensive SSL certificate validation
  */
 bool ConfigurationManager::validateSSLConfiguration() {
-    bool valid = true;
-    
-    if (!ssl_config_.ssl_enabled) {
-        return true; // No validation needed if SSL is disabled
-    }
-    
-    // We validate certificate file exists and is readable
-    if (ssl_config_.certificate_file.empty()) {
-        addValidationError("SSL enabled but no certificate file specified");
-        valid = false;
-    } else if (!validateCertificateFile(ssl_config_.certificate_file)) {
-        addValidationError("Invalid SSL certificate file: " + ssl_config_.certificate_file);
-        valid = false;
-    }
-    
-    // We validate private key file exists and is readable
-    if (ssl_config_.private_key_file.empty()) {
-        addValidationError("SSL enabled but no private key file specified");
-        valid = false;
-    } else if (!validatePrivateKeyFile(ssl_config_.private_key_file)) {
-        addValidationError("Invalid SSL private key file: " + ssl_config_.private_key_file);
-        valid = false;
-    }
-    
-    // We validate CA file if specified
-    if (!ssl_config_.ca_certificate_file.empty()) {
-        if (!validateCAFile(ssl_config_.ca_certificate_file)) {
-            addValidationError("Invalid SSL CA certificate file: " + ssl_config_.ca_certificate_file);
-            valid = false;
-        }
-    }
-    
-    // We validate SSL protocol version
-    if (ssl_config_.ssl_protocol_version < 0 || ssl_config_.ssl_protocol_version > 4) {
-        addValidationError("Invalid SSL protocol version: " + std::to_string(ssl_config_.ssl_protocol_version));
-        valid = false;
-    }
-    
-    return valid;
+  bool valid = true;
+
+  if (!ssl_config_.ssl_enabled) {
+    return true; // No validation needed if SSL is disabled
+  }
+
+  // We validate certificate file exists and is readable
+  if (ssl_config_.certificate_file.empty()) {
+    addValidationError("SSL enabled but no certificate file specified");
+    valid = false;
+  } else if (!validateCertificateFile(ssl_config_.certificate_file)) {
+    addValidationError("Invalid SSL certificate file: " +
+                       ssl_config_.certificate_file);
+    valid = false;
+  }
+
+  // We validate private key file exists and is readable
+  if (ssl_config_.private_key_file.empty()) {
+    addValidationError("SSL enabled but no private key file specified");
+    valid = false;
+  } else if (!validatePrivateKeyFile(ssl_config_.private_key_file)) {
+    addValidationError("Invalid SSL private key file: " +
+                       ssl_config_.private_key_file);
+    valid = false;
+  }
+
+  // We validate SSL protocol version
+  if (ssl_config_.ssl_protocol_version < 0 ||
+      ssl_config_.ssl_protocol_version > 4) {
+    addValidationError("Invalid SSL protocol version: " +
+                       std::to_string(ssl_config_.ssl_protocol_version));
+    valid = false;
+  }
+
+  return valid;
 }
 
 /**
@@ -466,59 +516,76 @@ bool ConfigurationManager::validateSSLConfiguration() {
  * This method checks physics parameters against theoretical constraints
  */
 bool ConfigurationManager::validatePhysicsConfiguration() {
-    bool valid = true;
-    
-    // We validate nuclear mass parameters
-    if (!ConfigurationUtils::isValidNuclearMass(physics_config_.default_parent_mass)) {
-        addValidationError("Invalid parent nucleus mass: " + std::to_string(physics_config_.default_parent_mass));
-        valid = false;
-    }
-    
-    // We validate excitation energy parameters
-    if (!ConfigurationUtils::isValidExcitationEnergy(physics_config_.default_excitation_energy)) {
-        addValidationError("Invalid excitation energy: " + std::to_string(physics_config_.default_excitation_energy));
-        valid = false;
-    }
-    
-    // We validate energy field limits
-    if (!ConfigurationUtils::isValidEnergyField(physics_config_.max_energy_field) ||
-        !ConfigurationUtils::isValidEnergyField(physics_config_.min_energy_field)) {
-        addValidationError("Invalid energy field limits: " + 
-                          std::to_string(physics_config_.min_energy_field) + " - " +
-                          std::to_string(physics_config_.max_energy_field));
-        valid = false;
-    }
-    
-    if (physics_config_.min_energy_field >= physics_config_.max_energy_field) {
-        addValidationError("Minimum energy field must be less than maximum energy field");
-        valid = false;
-    }
-    
-    // We validate conservation law tolerances
-    if (!ConfigurationUtils::areConservationLawTolerancesRealistic(physics_config_.conservation_tolerance)) {
-        addValidationError("Invalid conservation tolerance: " + std::to_string(physics_config_.conservation_tolerance));
-        valid = false;
-    }
-    
-    // We validate thread count
-    if (physics_config_.default_thread_count < 0 || physics_config_.default_thread_count > 256) {
-        addValidationError("Invalid thread count: " + std::to_string(physics_config_.default_thread_count));
-        valid = false;
-    }
-    
-    // We validate simulation rate
-    if (physics_config_.events_per_second <= 0.0 || physics_config_.events_per_second > 10000.0) {
-        addValidationError("Invalid events per second: " + std::to_string(physics_config_.events_per_second));
-        valid = false;
-    }
-    
-    // We validate maximum events per request
-    if (physics_config_.max_events_per_request < 1 || physics_config_.max_events_per_request > 10000000) {
-        addValidationError("Invalid max events per request: " + std::to_string(physics_config_.max_events_per_request));
-        valid = false;
-    }
-    
-    return valid;
+  bool valid = true;
+
+  // We validate nuclear mass parameters
+  if (!ConfigurationUtils::isValidNuclearMass(
+          physics_config_.default_parent_mass)) {
+    addValidationError("Invalid parent nucleus mass: " +
+                       std::to_string(physics_config_.default_parent_mass));
+    valid = false;
+  }
+
+  // We validate excitation energy parameters
+  if (!ConfigurationUtils::isValidExcitationEnergy(
+          physics_config_.default_excitation_energy)) {
+    addValidationError(
+        "Invalid excitation energy: " +
+        std::to_string(physics_config_.default_excitation_energy));
+    valid = false;
+  }
+
+  // We validate energy field limits
+  if (!ConfigurationUtils::isValidEnergyField(
+          physics_config_.max_energy_field) ||
+      !ConfigurationUtils::isValidEnergyField(
+          physics_config_.min_energy_field)) {
+    addValidationError("Invalid energy field limits: " +
+                       std::to_string(physics_config_.min_energy_field) +
+                       " - " +
+                       std::to_string(physics_config_.max_energy_field));
+    valid = false;
+  }
+
+  if (physics_config_.min_energy_field >= physics_config_.max_energy_field) {
+    addValidationError(
+        "Minimum energy field must be less than maximum energy field");
+    valid = false;
+  }
+
+  // We validate conservation law tolerances
+  if (!ConfigurationUtils::areConservationLawTolerancesRealistic(
+          physics_config_.conservation_tolerance)) {
+    addValidationError("Invalid conservation tolerance: " +
+                       std::to_string(physics_config_.conservation_tolerance));
+    valid = false;
+  }
+
+  // We validate thread count
+  if (physics_config_.default_thread_count < 0 ||
+      physics_config_.default_thread_count > 256) {
+    addValidationError("Invalid thread count: " +
+                       std::to_string(physics_config_.default_thread_count));
+    valid = false;
+  }
+
+  // We validate simulation rate
+  if (physics_config_.events_per_second <= 0.0 ||
+      physics_config_.events_per_second > 10000.0) {
+    addValidationError("Invalid events per second: " +
+                       std::to_string(physics_config_.events_per_second));
+    valid = false;
+  }
+
+  // We validate maximum events per request
+  if (physics_config_.max_events_per_request < 1 ||
+      physics_config_.max_events_per_request > 10000000) {
+    addValidationError("Invalid max events per request: " +
+                       std::to_string(physics_config_.max_events_per_request));
+    valid = false;
+  }
+
+  return valid;
 }
 
 /**
@@ -526,146 +593,163 @@ bool ConfigurationManager::validatePhysicsConfiguration() {
  * This method checks logging settings and file permissions
  */
 bool ConfigurationManager::validateLoggingConfiguration() {
-    bool valid = true;
-    
-    // We validate log level
-    std::vector<std::string> valid_levels = {"debug", "info", "warn", "error"};
-    if (std::find(valid_levels.begin(), valid_levels.end(), logging_config_.log_level) == valid_levels.end()) {
-        addValidationError("Invalid log level: " + logging_config_.log_level);
-        valid = false;
-    }
-    
-    // We validate log file paths if file logging is enabled
-    if (logging_config_.enable_file_logging) {
-        std::vector<std::string> log_files = {
-            logging_config_.access_log_path,
-            logging_config_.error_log_path,
-            logging_config_.debug_log_path
-        };
-        
-        for (const auto& log_file : log_files) {
-            std::string log_dir = log_file.substr(0, log_file.find_last_of('/'));
-            if (!ConfigurationUtils::validateDirectoryPath(log_dir, true)) {
-                addValidationError("Log directory not writable: " + log_dir);
-                valid = false;
-            }
-        }
-    }
-    
-    // We validate log file size limits
-    if (logging_config_.max_log_file_size < 1024 || logging_config_.max_log_file_size > 1073741824) {
-        addValidationError("Invalid max log file size: " + std::to_string(logging_config_.max_log_file_size));
-        valid = false;
-    }
-    
-    // We validate log rotation count
-    if (logging_config_.log_rotation_count < 1 || logging_config_.log_rotation_count > 100) {
-        addValidationError("Invalid log rotation count: " + std::to_string(logging_config_.log_rotation_count));
-        valid = false;
-    }
+  bool valid = true;
 
-    return valid;
+  // We validate log level
+  std::vector<std::string> valid_levels = {"debug", "info", "warn", "error"};
+  if (std::find(valid_levels.begin(), valid_levels.end(),
+                logging_config_.log_level) == valid_levels.end()) {
+    addValidationError("Invalid log level: " + logging_config_.log_level);
+    valid = false;
+  }
+
+  // We validate log file paths if file logging is enabled
+  if (logging_config_.enable_file_logging) {
+    std::vector<std::string> log_files = {logging_config_.access_log_path,
+                                          logging_config_.error_log_path,
+                                          logging_config_.debug_log_path};
+
+    for (const auto &log_file : log_files) {
+      std::string log_dir = log_file.substr(0, log_file.find_last_of('/'));
+      if (!ConfigurationUtils::validateDirectoryPath(log_dir, true)) {
+        addValidationError("Log directory not writable: " + log_dir);
+        valid = false;
+      }
+    }
+  }
+
+  // We validate log file size limits
+  if (logging_config_.max_log_file_size < 1024 ||
+      logging_config_.max_log_file_size > 1073741824) {
+    addValidationError("Invalid max log file size: " +
+                       std::to_string(logging_config_.max_log_file_size));
+    valid = false;
+  }
+
+  // We validate log rotation count
+  if (logging_config_.log_rotation_count < 1 ||
+      logging_config_.log_rotation_count > 100) {
+    addValidationError("Invalid log rotation count: " +
+                       std::to_string(logging_config_.log_rotation_count));
+    valid = false;
+  }
+
+  return valid;
 }
 
 bool ConfigurationManager::validateMediaStreamingConfiguration() {
-    bool valid = true;
+  bool valid = true;
 
-    if (media_streaming_config_.media_streaming_enabled) {
-        if (media_streaming_config_.media_root.empty()) {
-            addValidationError("Media streaming enabled but media_root not set");
-            valid = false;
-        } else if (!ConfigurationUtils::validateDirectoryPath(media_streaming_config_.media_root, false)) {
-            addValidationError("Media root directory does not exist: " + media_streaming_config_.media_root);
-            valid = false;
-        }
-
-        if (media_streaming_config_.icecast_mount.empty()) {
-            addValidationError("Media streaming enabled but icecast_mount not set");
-            valid = false;
-        }
+  if (media_streaming_config_.media_streaming_enabled) {
+    if (media_streaming_config_.media_root.empty()) {
+      addValidationError("Media streaming enabled but media_root not set");
+      valid = false;
+    } else if (!ConfigurationUtils::validateDirectoryPath(
+                   media_streaming_config_.media_root, false)) {
+      addValidationError("Media root directory does not exist: " +
+                         media_streaming_config_.media_root);
+      valid = false;
     }
 
-    return valid;
+    if (media_streaming_config_.icecast_mount.empty()) {
+      addValidationError("Media streaming enabled but icecast_mount not set");
+      valid = false;
+    }
+  }
+
+  return valid;
 }
 
 /**
- * We process environment variable overrides following hybrid configuration strategy
- * This method applies environment variables to override configuration file settings
+ * We process environment variable overrides following hybrid configuration
+ * strategy This method applies environment variables to override configuration
+ * file settings
  */
 void ConfigurationManager::processEnvironmentOverrides() {
-    // We process network configuration overrides
-    std::string env_bind_ip = getEnvironmentVariable("TERNARY_BIND_IP");
-    if (!env_bind_ip.empty()) {
-        network_config_.bind_ip = env_bind_ip;
-    }
-    
-    std::string env_bind_port = getEnvironmentVariable("TERNARY_BIND_PORT");
-    if (!env_bind_port.empty()) {
-        network_config_.bind_port = std::stoi(env_bind_port);
-    }
-    
-    std::string env_enable_ssl = getEnvironmentVariable("TERNARY_ENABLE_SSL");
-    if (!env_enable_ssl.empty()) {
-        network_config_.enable_ssl = (env_enable_ssl == "true" || env_enable_ssl == "1");
-    }
-    
-    // We process daemon configuration overrides
-    std::string env_daemon_mode = getEnvironmentVariable("TERNARY_DAEMON_MODE");
-    if (!env_daemon_mode.empty()) {
-        daemon_config_.daemon_mode = (env_daemon_mode == "true" || env_daemon_mode == "1");
-    }
-    
-    // We process physics configuration overrides
-    std::string env_parent_mass = getEnvironmentVariable("TERNARY_PARENT_MASS");
-    if (!env_parent_mass.empty()) {
-        physics_config_.default_parent_mass = std::stod(env_parent_mass);
-    }
-    
-    std::string env_excitation_energy = getEnvironmentVariable("TERNARY_EXCITATION_ENERGY");
-    if (!env_excitation_energy.empty()) {
-        physics_config_.default_excitation_energy = std::stod(env_excitation_energy);
-    }
-    
-    std::string env_events_per_second = getEnvironmentVariable("TERNARY_EVENTS_PER_SECOND");
-    if (!env_events_per_second.empty()) {
-        physics_config_.events_per_second = std::stod(env_events_per_second);
-    }
+  // We process network configuration overrides
+  std::string env_bind_ip = getEnvironmentVariable("TERNARY_BIND_IP");
+  if (!env_bind_ip.empty()) {
+    network_config_.bind_ip = env_bind_ip;
+  }
 
-    // We process logging configuration overrides
-    std::string env_log_level = getEnvironmentVariable("TERNARY_LOG_LEVEL");
-    if (!env_log_level.empty()) {
-        logging_config_.log_level = env_log_level;
-    }
+  std::string env_bind_port = getEnvironmentVariable("TERNARY_BIND_PORT");
+  if (!env_bind_port.empty()) {
+    network_config_.bind_port = std::stoi(env_bind_port);
+  }
 
-    std::string env_verbose_output = getEnvironmentVariable("TERNARY_VERBOSE_OUTPUT");
-    if (!env_verbose_output.empty()) {
-        logging_config_.verbose_output = (env_verbose_output == "true" || env_verbose_output == "1");
-    }
+  std::string env_enable_ssl = getEnvironmentVariable("TERNARY_ENABLE_SSL");
+  if (!env_enable_ssl.empty()) {
+    network_config_.enable_ssl =
+        (env_enable_ssl == "true" || env_enable_ssl == "1");
+  }
 
-    // We process media streaming overrides
-    std::string env_streaming_enabled = getEnvironmentVariable("TERNARY_MEDIA_STREAMING_ENABLED");
-    if (!env_streaming_enabled.empty()) {
-        media_streaming_config_.media_streaming_enabled = (env_streaming_enabled == "true" || env_streaming_enabled == "1");
-    }
+  // We process daemon configuration overrides
+  std::string env_daemon_mode = getEnvironmentVariable("TERNARY_DAEMON_MODE");
+  if (!env_daemon_mode.empty()) {
+    daemon_config_.daemon_mode =
+        (env_daemon_mode == "true" || env_daemon_mode == "1");
+  }
 
-    std::string env_media_root = getEnvironmentVariable("TERNARY_MEDIA_ROOT");
-    if (!env_media_root.empty()) {
-        media_streaming_config_.media_root = env_media_root;
-    }
+  // We process physics configuration overrides
+  std::string env_parent_mass = getEnvironmentVariable("TERNARY_PARENT_MASS");
+  if (!env_parent_mass.empty()) {
+    physics_config_.default_parent_mass = std::stod(env_parent_mass);
+  }
 
-    std::string env_icecast_mount = getEnvironmentVariable("TERNARY_ICECAST_MOUNT");
-    if (!env_icecast_mount.empty()) {
-        media_streaming_config_.icecast_mount = env_icecast_mount;
-    }
+  std::string env_excitation_energy =
+      getEnvironmentVariable("TERNARY_EXCITATION_ENERGY");
+  if (!env_excitation_energy.empty()) {
+    physics_config_.default_excitation_energy =
+        std::stod(env_excitation_energy);
+  }
+
+  std::string env_events_per_second =
+      getEnvironmentVariable("TERNARY_EVENTS_PER_SECOND");
+  if (!env_events_per_second.empty()) {
+    physics_config_.events_per_second = std::stod(env_events_per_second);
+  }
+
+  // We process logging configuration overrides
+  std::string env_log_level = getEnvironmentVariable("TERNARY_LOG_LEVEL");
+  if (!env_log_level.empty()) {
+    logging_config_.log_level = env_log_level;
+  }
+
+  std::string env_verbose_output =
+      getEnvironmentVariable("TERNARY_VERBOSE_OUTPUT");
+  if (!env_verbose_output.empty()) {
+    logging_config_.verbose_output =
+        (env_verbose_output == "true" || env_verbose_output == "1");
+  }
+
+  // We process media streaming overrides
+  std::string env_streaming_enabled =
+      getEnvironmentVariable("TERNARY_MEDIA_STREAMING_ENABLED");
+  if (!env_streaming_enabled.empty()) {
+    media_streaming_config_.media_streaming_enabled =
+        (env_streaming_enabled == "true" || env_streaming_enabled == "1");
+  }
+
+  std::string env_media_root = getEnvironmentVariable("TERNARY_MEDIA_ROOT");
+  if (!env_media_root.empty()) {
+    media_streaming_config_.media_root = env_media_root;
+  }
+
+  std::string env_icecast_mount =
+      getEnvironmentVariable("TERNARY_ICECAST_MOUNT");
+  if (!env_icecast_mount.empty()) {
+    media_streaming_config_.icecast_mount = env_icecast_mount;
+  }
 }
 
 /**
  * We get environment variable with default value
  * This method safely retrieves environment variables with fallback
  */
-std::string ConfigurationManager::getEnvironmentVariable(const std::string& key, const std::string& default_value) const {
-    const char* env_value = std::getenv(key.c_str());
-    return env_value ? std::string(env_value) : default_value;
+std::string ConfigurationManager::getEnvironmentVariable(
+    const std::string &key, const std::string &default_value) const {
+  const char *env_value = std::getenv(key.c_str());
+  return env_value ? std::string(env_value) : default_value;
 }
 
 /**
@@ -673,70 +757,65 @@ std::string ConfigurationManager::getEnvironmentVariable(const std::string& key,
  * This method checks certificate validity and extracts expiration information
  */
 bool ConfigurationManager::validateSSLCertificates() {
-    if (!ssl_config_.ssl_enabled) {
-        return true;
+  if (!ssl_config_.ssl_enabled) {
+    return true;
+  }
+
+  bool valid = true;
+
+  // We validate certificate file
+  if (!ssl_config_.certificate_file.empty()) {
+    if (validateCertificateFile(ssl_config_.certificate_file)) {
+      ssl_config_.cert_expiry =
+          extractCertificateExpiry(ssl_config_.certificate_file);
+    } else {
+      valid = false;
     }
-    
-    bool valid = true;
-    
-    // We validate certificate file
-    if (!ssl_config_.certificate_file.empty()) {
-        if (validateCertificateFile(ssl_config_.certificate_file)) {
-            ssl_config_.cert_expiry = extractCertificateExpiry(ssl_config_.certificate_file);
-        } else {
-            valid = false;
-        }
+  }
+
+  // We validate private key file
+  if (!ssl_config_.private_key_file.empty()) {
+    if (!validatePrivateKeyFile(ssl_config_.private_key_file)) {
+      valid = false;
     }
-    
-    // We validate private key file
-    if (!ssl_config_.private_key_file.empty()) {
-        if (!validatePrivateKeyFile(ssl_config_.private_key_file)) {
-            valid = false;
-        }
-    }
-    
-    // We validate CA file if specified
-    if (!ssl_config_.ca_certificate_file.empty()) {
-        if (!validateCAFile(ssl_config_.ca_certificate_file)) {
-            valid = false;
-        }
-    }
-    
-    return valid;
+  }
+
+  return valid;
 }
 
 /**
  * We provide accessor methods for configuration structures
  * These methods return const references to prevent unauthorized modification
  */
-const NetworkConfiguration& ConfigurationManager::getNetworkConfig() const {
-    std::lock_guard<std::mutex> lock(config_mutex_);
-    return network_config_;
+const NetworkConfiguration &ConfigurationManager::getNetworkConfig() const {
+  std::lock_guard<std::mutex> lock(config_mutex_);
+  return network_config_;
 }
 
-const DaemonConfiguration& ConfigurationManager::getDaemonConfig() const {
-    std::lock_guard<std::mutex> lock(config_mutex_);
-    return daemon_config_;
+const DaemonConfiguration &ConfigurationManager::getDaemonConfig() const {
+  std::lock_guard<std::mutex> lock(config_mutex_);
+  return daemon_config_;
 }
 
-const SSLConfiguration& ConfigurationManager::getSSLConfig() const {
-    std::lock_guard<std::mutex> lock(config_mutex_);
-    return ssl_config_;
+const SSLConfiguration &ConfigurationManager::getSSLConfig() const {
+  std::lock_guard<std::mutex> lock(config_mutex_);
+  return ssl_config_;
 }
 
-const PhysicsConfiguration& ConfigurationManager::getPhysicsConfig() const {
-    std::lock_guard<std::mutex> lock(config_mutex_);
-    return physics_config_;
+const PhysicsConfiguration &ConfigurationManager::getPhysicsConfig() const {
+  std::lock_guard<std::mutex> lock(config_mutex_);
+  return physics_config_;
 }
 
-const LoggingConfiguration& ConfigurationManager::getLoggingConfig() const {
-    std::lock_guard<std::mutex> lock(config_mutex_);
-    return logging_config_;
+const LoggingConfiguration &ConfigurationManager::getLoggingConfig() const {
+  std::lock_guard<std::mutex> lock(config_mutex_);
+  return logging_config_;
 }
 
-const MediaStreamingConfiguration& ConfigurationManager::getMediaStreamingConfig() const {
-    std::lock_guard<std::mutex> lock(config_mutex_);
-    return media_streaming_config_;
+const MediaStreamingConfiguration &
+ConfigurationManager::getMediaStreamingConfig() const {
+  std::lock_guard<std::mutex> lock(config_mutex_);
+  return media_streaming_config_;
 }
 
 // We implement utility functions for configuration management
@@ -747,45 +826,44 @@ namespace ConfigurationUtils {
  * This function searches for configuration files across different platforms
  */
 std::string findDefaultConfigFile() {
-    std::vector<std::string> search_paths = {
-        "./configs/daemon.conf",
-        "./daemon.conf",
-        "/etc/ternary-fission/daemon.conf",
-        "/usr/local/etc/ternary-fission/daemon.conf",
-        std::string(getenv("HOME") ? getenv("HOME") : "") + "/.config/ternary-fission/daemon.conf"
-    };
-    
-    for (const auto& path : search_paths) {
-        if (!path.empty()) {
-            struct stat st;
-            if (stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode)) {
-                return path;
-            }
-        }
+  std::vector<std::string> search_paths = {
+      "./configs/daemon.conf", "./daemon.conf",
+      "/etc/ternary-fission/daemon.conf",
+      "/usr/local/etc/ternary-fission/daemon.conf",
+      std::string(getenv("HOME") ? getenv("HOME") : "") +
+          "/.config/ternary-fission/daemon.conf"};
+
+  for (const auto &path : search_paths) {
+    if (!path.empty()) {
+      struct stat st;
+      if (stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode)) {
+        return path;
+      }
     }
-    
-    return ""; // No default config file found
+  }
+
+  return ""; // No default config file found
 }
 
 /**
  * We validate IP address format using inet_pton
  * This function checks both IPv4 and IPv6 address formats
  */
-bool validateIPAddress(const std::string& ip_address) {
-    struct sockaddr_in sa4;
-    struct sockaddr_in6 sa6;
-    
-    // We check IPv4 format
-    if (inet_pton(AF_INET, ip_address.c_str(), &(sa4.sin_addr)) == 1) {
-        return true;
-    }
-    
-    // We check IPv6 format
-    if (inet_pton(AF_INET6, ip_address.c_str(), &(sa6.sin6_addr)) == 1) {
-        return true;
-    }
-    
-    return false;
+bool validateIPAddress(const std::string &ip_address) {
+  struct sockaddr_in sa4;
+  struct sockaddr_in6 sa6;
+
+  // We check IPv4 format
+  if (inet_pton(AF_INET, ip_address.c_str(), &(sa4.sin_addr)) == 1) {
+    return true;
+  }
+
+  // We check IPv6 format
+  if (inet_pton(AF_INET6, ip_address.c_str(), &(sa6.sin6_addr)) == 1) {
+    return true;
+  }
+
+  return false;
 }
 
 /**
@@ -793,47 +871,47 @@ bool validateIPAddress(const std::string& ip_address) {
  * This function checks if port is within valid range and not reserved
  */
 bool validatePortNumber(int port) {
-    return port > 0 && port <= 65535 && port != 22; // Exclude SSH port for safety
+  return port > 0 && port <= 65535 && port != 22; // Exclude SSH port for safety
 }
 
 /**
  * We validate file path existence and permissions
  * This function checks file accessibility based on requirements
  */
-bool validateFilePath(const std::string& path, bool must_exist) {
-    if (path.empty()) {
-        return false;
-    }
-    
-    struct stat st;
-    if (stat(path.c_str(), &st) == 0) {
-        return S_ISREG(st.st_mode) && (access(path.c_str(), R_OK) == 0);
-    }
-    
-    return !must_exist;
+bool validateFilePath(const std::string &path, bool must_exist) {
+  if (path.empty()) {
+    return false;
+  }
+
+  struct stat st;
+  if (stat(path.c_str(), &st) == 0) {
+    return S_ISREG(st.st_mode) && (access(path.c_str(), R_OK) == 0);
+  }
+
+  return !must_exist;
 }
 
 /**
  * We validate directory path and optionally create it
  * This function ensures directory exists and is writable
  */
-bool validateDirectoryPath(const std::string& path, bool create_if_missing) {
-    if (path.empty()) {
-        return false;
-    }
-    
-    struct stat st;
-    if (stat(path.c_str(), &st) == 0) {
-        return S_ISDIR(st.st_mode) && (access(path.c_str(), W_OK) == 0);
-    }
-    
-    if (create_if_missing) {
-        // We attempt to create the directory
-        std::string mkdir_cmd = "mkdir -p " + path;
-        return system(mkdir_cmd.c_str()) == 0;
-    }
-    
+bool validateDirectoryPath(const std::string &path, bool create_if_missing) {
+  if (path.empty()) {
     return false;
+  }
+
+  struct stat st;
+  if (stat(path.c_str(), &st) == 0) {
+    return S_ISDIR(st.st_mode) && (access(path.c_str(), W_OK) == 0);
+  }
+
+  if (create_if_missing) {
+    // We attempt to create the directory
+    std::string mkdir_cmd = "mkdir -p " + path;
+    return system(mkdir_cmd.c_str()) == 0;
+  }
+
+  return false;
 }
 
 /**
@@ -841,125 +919,136 @@ bool validateDirectoryPath(const std::string& path, bool create_if_missing) {
  * These functions ensure simulation parameters are physically realistic
  */
 bool isValidNuclearMass(double mass) {
-    return mass >= 1.0 && mass <= 300.0; // Reasonable range for nuclear masses
+  return mass >= 1.0 && mass <= 300.0; // Reasonable range for nuclear masses
 }
 
 bool isValidExcitationEnergy(double energy) {
-    return energy >= 0.0 && energy <= 50.0; // Reasonable range for excitation energies
+  return energy >= 0.0 &&
+         energy <= 50.0; // Reasonable range for excitation energies
 }
 
 bool isValidEnergyField(double energy) {
-    return energy >= 0.01 && energy <= 10000.0; // Reasonable range for energy fields
+  return energy >= 0.01 &&
+         energy <= 10000.0; // Reasonable range for energy fields
 }
 
 bool areConservationLawTolerancesRealistic(double tolerance) {
-    return tolerance >= 1e-12 && tolerance <= 1e-3; // Reasonable numerical tolerance range
+  return tolerance >= 1e-12 &&
+         tolerance <= 1e-3; // Reasonable numerical tolerance range
 }
 
 } // namespace ConfigurationUtils
 
 // We implement remaining private methods...
 
-std::string ConfigurationManager::getConfigValue(const std::string& key, const std::string& default_value) const {
-    auto it = raw_config_.find(key);
-    return (it != raw_config_.end()) ? it->second : default_value;
+std::string
+ConfigurationManager::getConfigValue(const std::string &key,
+                                     const std::string &default_value) const {
+  auto it = raw_config_.find(key);
+  return (it != raw_config_.end()) ? it->second : default_value;
 }
 
-int ConfigurationManager::getConfigInt(const std::string& key, int default_value) const {
-    std::string value_str = getConfigValue(key, "");
-    if (value_str.empty()) {
-        return default_value;
-    }
-    
-    try {
-        return std::stoi(value_str);
-    } catch (const std::exception&) {
-        return default_value;
-    }
+int ConfigurationManager::getConfigInt(const std::string &key,
+                                       int default_value) const {
+  std::string value_str = getConfigValue(key, "");
+  if (value_str.empty()) {
+    return default_value;
+  }
+
+  try {
+    return std::stoi(value_str);
+  } catch (const std::exception &) {
+    return default_value;
+  }
 }
 
-double ConfigurationManager::getConfigDouble(const std::string& key, double default_value) const {
-    std::string value_str = getConfigValue(key, "");
-    if (value_str.empty()) {
-        return default_value;
-    }
-    
-    try {
-        return std::stod(value_str);
-    } catch (const std::exception&) {
-        return default_value;
-    }
+double ConfigurationManager::getConfigDouble(const std::string &key,
+                                             double default_value) const {
+  std::string value_str = getConfigValue(key, "");
+  if (value_str.empty()) {
+    return default_value;
+  }
+
+  try {
+    return std::stod(value_str);
+  } catch (const std::exception &) {
+    return default_value;
+  }
 }
 
-bool ConfigurationManager::getConfigBool(const std::string& key, bool default_value) const {
-    std::string value_str = getConfigValue(key, "");
-    if (value_str.empty()) {
-        return default_value;
-    }
-    
-    std::transform(value_str.begin(), value_str.end(), value_str.begin(), ::tolower);
-    return value_str == "true" || value_str == "1" || value_str == "yes" || value_str == "on";
+bool ConfigurationManager::getConfigBool(const std::string &key,
+                                         bool default_value) const {
+  std::string value_str = getConfigValue(key, "");
+  if (value_str.empty()) {
+    return default_value;
+  }
+
+  std::transform(value_str.begin(), value_str.end(), value_str.begin(),
+                 ::tolower);
+  return value_str == "true" || value_str == "1" || value_str == "yes" ||
+         value_str == "on";
 }
 
 void ConfigurationManager::clearValidationMessages() {
-    validation_errors_.clear();
-    validation_warnings_.clear();
+  validation_errors_.clear();
+  validation_warnings_.clear();
 }
 
-void ConfigurationManager::addValidationError(const std::string& error) {
-    validation_errors_.push_back(error);
+void ConfigurationManager::addValidationError(const std::string &error) {
+  validation_errors_.push_back(error);
 }
 
-void ConfigurationManager::addValidationWarning(const std::string& warning) {
-    validation_warnings_.push_back(warning);
+void ConfigurationManager::addValidationWarning(const std::string &warning) {
+  validation_warnings_.push_back(warning);
 }
 
-bool ConfigurationManager::fileExists(const std::string& path) const {
-    struct stat st;
-    return stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode);
+bool ConfigurationManager::fileExists(const std::string &path) const {
+  struct stat st;
+  return stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode);
 }
 
-bool ConfigurationManager::isFileReadable(const std::string& path) const {
-    return access(path.c_str(), R_OK) == 0;
+bool ConfigurationManager::isFileReadable(const std::string &path) const {
+  return access(path.c_str(), R_OK) == 0;
 }
 
-std::chrono::system_clock::time_point ConfigurationManager::getFileModificationTime(const std::string& path) const {
-    struct stat st;
-    if (stat(path.c_str(), &st) == 0) {
-        return std::chrono::system_clock::from_time_t(st.st_mtime);
-    }
-    return std::chrono::system_clock::time_point::min();
+std::chrono::system_clock::time_point
+ConfigurationManager::getFileModificationTime(const std::string &path) const {
+  struct stat st;
+  if (stat(path.c_str(), &st) == 0) {
+    return std::chrono::system_clock::from_time_t(st.st_mtime);
+  }
+  return std::chrono::system_clock::time_point::min();
 }
 
-std::vector<std::string> ConfigurationManager::getConfigStringList(const std::string& key) const {
-    std::vector<std::string> values;
-    std::string raw = getConfigValue(key, "");
-    if (raw.empty()) {
-        return values;
-    }
-
-    std::stringstream ss(raw);
-    std::string item;
-    while (std::getline(ss, item, ',')) {
-        values.push_back(item);
-    }
+std::vector<std::string>
+ConfigurationManager::getConfigStringList(const std::string &key) const {
+  std::vector<std::string> values;
+  std::string raw = getConfigValue(key, "");
+  if (raw.empty()) {
     return values;
+  }
+
+  std::stringstream ss(raw);
+  std::string item;
+  while (std::getline(ss, item, ',')) {
+    values.push_back(item);
+  }
+  return values;
 }
 
-bool ConfigurationManager::validateCertificateFile(const std::string& cert_path) {
-    return fileExists(cert_path) && isFileReadable(cert_path);
+bool ConfigurationManager::validateCertificateFile(
+    const std::string &cert_path) {
+  return fileExists(cert_path) && isFileReadable(cert_path);
 }
 
-bool ConfigurationManager::validatePrivateKeyFile(const std::string& key_path) {
-    return fileExists(key_path) && isFileReadable(key_path);
+bool ConfigurationManager::validatePrivateKeyFile(const std::string &key_path) {
+  return fileExists(key_path) && isFileReadable(key_path);
 }
 
-bool ConfigurationManager::validateCAFile(const std::string& ca_path) {
-    return fileExists(ca_path) && isFileReadable(ca_path);
-}
-
-std::chrono::system_clock::time_point ConfigurationManager::extractCertificateExpiry(const std::string& /*cert_path*/) {
-    return std::chrono::system_clock::now();
+std::chrono::system_clock::time_point
+ConfigurationManager::extractCertificateExpiry(
+    const std::string & /*cert_path*/) {
+  return std::chrono::system_clock::now();
 }
 
 } // namespace TernaryFission

--- a/src/cpp/http.ternary.fission.server.cpp
+++ b/src/cpp/http.ternary.fission.server.cpp
@@ -2,27 +2,32 @@
  * File: src/cpp/http.ternary.fission.server.cpp
  * Author: bthlops (David StJ)
  * Date: January 31, 2025
- * Title: HTTP/HTTPS REST API Server Implementation for Ternary Fission Daemon Operations
- * Purpose: Complete implementation of HTTP server with SSL/TLS support and physics API endpoints
- * Reason: Provides REST API interface for distributed daemon architecture and physics simulations
+ * Title: HTTP/HTTPS REST API Server Implementation for Ternary Fission Daemon
+ * Operations Purpose: Complete implementation of HTTP server with SSL/TLS
+ * support and physics API endpoints Reason: Provides REST API interface for
+ * distributed daemon architecture and physics simulations
  *
  * Change Log:
- * 2025-01-31: Initial implementation for distributed daemon architecture Phase 1
- *             Added complete HTTP/HTTPS server implementation with cpp-httplib
+ * 2025-01-31: Initial implementation for distributed daemon architecture Phase
+ * 1 Added complete HTTP/HTTPS server implementation with cpp-httplib
  *             Implemented all Go server API endpoints with JSON serialization
  *             Added SSL/TLS certificate management and validation
  *             Integrated physics simulation engine with thread-safe API access
  *             Added WebSocket real-time monitoring with broadcast capabilities
- *             Implemented comprehensive middleware stack (CORS, logging, metrics)
- *             Added energy field management with persistence and validation
+ *             Implemented comprehensive middleware stack (CORS, logging,
+ * metrics) Added energy field management with persistence and validation
  *             Integrated system metrics collection and performance monitoring
  *
  * Carry-over Context:
- * - This implementation provides complete HTTP server functionality for daemon operations
- * - All API endpoints match Go server structure for seamless Phase 2 integration
+ * - This implementation provides complete HTTP server functionality for daemon
+ * operations
+ * - All API endpoints match Go server structure for seamless Phase 2
+ * integration
  * - SSL certificate management enables production HTTPS deployment
- * - Physics API endpoints provide JSON interface to simulation engine calculations
- * - WebSocket broadcasting enables real-time monitoring of energy field operations
+ * - Physics API endpoints provide JSON interface to simulation engine
+ * calculations
+ * - WebSocket broadcasting enables real-time monitoring of energy field
+ * operations
  * - Thread-safe implementation supports concurrent request processing
  * - Next: Integration with daemon class and systemd service deployment
  */
@@ -30,22 +35,22 @@
 #include "http.ternary.fission.server.h"
 #include "physics.utilities.h"
 #include "system.metrics.h"
-#include <iostream>
-#include <sstream>
-#include <fstream>
-#include <iomanip>
-#include <random>
 #include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <random>
+#include <signal.h>
+#include <sstream>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <signal.h>
-#include <openssl/ssl.h>
-#include <openssl/err.h>
-#include <openssl/x509.h>
-#include <openssl/pem.h>
 
 namespace TernaryFission {
 
@@ -58,78 +63,85 @@ namespace TernaryFission {
  * This method converts internal energy field state to client-readable JSON
  */
 Json::Value EnergyFieldResponse::toJson() const {
-    Json::Value json;
-    json["field_id"] = field_id;
-    json["energy_level_mev"] = energy_level_mev;
-    json["stability_factor"] = stability_factor;
-    json["dissipation_rate"] = dissipation_rate;
-    json["base_three_mev_per_sec"] = base_three_mev_per_sec;
-    json["entropy_factor"] = entropy_factor;
-    json["active"] = active;
-    json["total_energy_mev"] = total_energy_mev;
-    json["status"] = status;
-    
-    // We format timestamps in ISO 8601 format
-    auto created_time_t = std::chrono::system_clock::to_time_t(created_at);
-    auto updated_time_t = std::chrono::system_clock::to_time_t(last_updated);
-    
-    std::stringstream created_ss, updated_ss;
-    created_ss << std::put_time(std::gmtime(&created_time_t), "%Y-%m-%dT%H:%M:%SZ");
-    updated_ss << std::put_time(std::gmtime(&updated_time_t), "%Y-%m-%dT%H:%M:%SZ");
-    
-    json["created_at"] = created_ss.str();
-    json["last_updated"] = updated_ss.str();
-    
-    return json;
+  Json::Value json;
+  json["field_id"] = field_id;
+  json["energy_level_mev"] = energy_level_mev;
+  json["stability_factor"] = stability_factor;
+  json["dissipation_rate"] = dissipation_rate;
+  json["base_three_mev_per_sec"] = base_three_mev_per_sec;
+  json["entropy_factor"] = entropy_factor;
+  json["active"] = active;
+  json["total_energy_mev"] = total_energy_mev;
+  json["status"] = status;
+
+  // We format timestamps in ISO 8601 format
+  auto created_time_t = std::chrono::system_clock::to_time_t(created_at);
+  auto updated_time_t = std::chrono::system_clock::to_time_t(last_updated);
+
+  std::stringstream created_ss, updated_ss;
+  created_ss << std::put_time(std::gmtime(&created_time_t),
+                              "%Y-%m-%dT%H:%M:%SZ");
+  updated_ss << std::put_time(std::gmtime(&updated_time_t),
+                              "%Y-%m-%dT%H:%M:%SZ");
+
+  json["created_at"] = created_ss.str();
+  json["last_updated"] = updated_ss.str();
+
+  return json;
 }
 
 /**
  * We deserialize energy field data from JSON format for API requests
  * This method converts client JSON requests to internal energy field state
  */
-bool EnergyFieldResponse::fromJson(const Json::Value& json) {
-    try {
-        if (json.isMember("field_id") && json["field_id"].isString()) {
-            field_id = json["field_id"].asString();
-        }
-        
-        if (json.isMember("energy_level_mev") && json["energy_level_mev"].isNumeric()) {
-            energy_level_mev = json["energy_level_mev"].asDouble();
-        }
-        
-        if (json.isMember("stability_factor") && json["stability_factor"].isNumeric()) {
-            stability_factor = json["stability_factor"].asDouble();
-        }
-        
-        if (json.isMember("dissipation_rate") && json["dissipation_rate"].isNumeric()) {
-            dissipation_rate = json["dissipation_rate"].asDouble();
-        }
-        
-        if (json.isMember("base_three_mev_per_sec") && json["base_three_mev_per_sec"].isNumeric()) {
-            base_three_mev_per_sec = json["base_three_mev_per_sec"].asDouble();
-        }
-        
-        if (json.isMember("entropy_factor") && json["entropy_factor"].isNumeric()) {
-            entropy_factor = json["entropy_factor"].asDouble();
-        }
-
-        if (json.isMember("active") && json["active"].isBool()) {
-            active = json["active"].asBool();
-        }
-
-        if (json.isMember("total_energy_mev") && json["total_energy_mev"].isNumeric()) {
-            total_energy_mev = json["total_energy_mev"].asDouble();
-        }
-
-        if (json.isMember("status") && json["status"].isString()) {
-            status = json["status"].asString();
-        }
-        
-        return true;
-    } catch (const std::exception& e) {
-        std::cerr << "Error parsing energy field JSON: " << e.what() << std::endl;
-        return false;
+bool EnergyFieldResponse::fromJson(const Json::Value &json) {
+  try {
+    if (json.isMember("field_id") && json["field_id"].isString()) {
+      field_id = json["field_id"].asString();
     }
+
+    if (json.isMember("energy_level_mev") &&
+        json["energy_level_mev"].isNumeric()) {
+      energy_level_mev = json["energy_level_mev"].asDouble();
+    }
+
+    if (json.isMember("stability_factor") &&
+        json["stability_factor"].isNumeric()) {
+      stability_factor = json["stability_factor"].asDouble();
+    }
+
+    if (json.isMember("dissipation_rate") &&
+        json["dissipation_rate"].isNumeric()) {
+      dissipation_rate = json["dissipation_rate"].asDouble();
+    }
+
+    if (json.isMember("base_three_mev_per_sec") &&
+        json["base_three_mev_per_sec"].isNumeric()) {
+      base_three_mev_per_sec = json["base_three_mev_per_sec"].asDouble();
+    }
+
+    if (json.isMember("entropy_factor") && json["entropy_factor"].isNumeric()) {
+      entropy_factor = json["entropy_factor"].asDouble();
+    }
+
+    if (json.isMember("active") && json["active"].isBool()) {
+      active = json["active"].asBool();
+    }
+
+    if (json.isMember("total_energy_mev") &&
+        json["total_energy_mev"].isNumeric()) {
+      total_energy_mev = json["total_energy_mev"].asDouble();
+    }
+
+    if (json.isMember("status") && json["status"].isString()) {
+      status = json["status"].asString();
+    }
+
+    return true;
+  } catch (const std::exception &e) {
+    std::cerr << "Error parsing energy field JSON: " << e.what() << std::endl;
+    return false;
+  }
 }
 
 // =============================================================================
@@ -141,28 +153,31 @@ bool EnergyFieldResponse::fromJson(const Json::Value& json) {
  * This method provides comprehensive system health information to clients
  */
 Json::Value SystemStatusResponse::toJson() const {
-    Json::Value json;
-    json["uptime_seconds"] = static_cast<Json::Int64>(uptime_seconds);
-    json["total_fission_events"] = static_cast<Json::UInt64>(total_fission_events);
-    json["total_energy_simulated_mev"] = total_energy_simulated_mev;
-    json["active_energy_fields"] = static_cast<Json::Int64>(active_energy_fields);
-    json["peak_memory_usage_bytes"] = static_cast<Json::UInt64>(peak_memory_usage_bytes);
-    json["average_calculation_time_microseconds"] = average_calc_time_microseconds;
-    json["total_calculations"] = static_cast<Json::UInt64>(total_calculations);
-    json["simulation_running"] = simulation_running;
-    json["cpu_usage_percent"] = cpu_usage_percent;
-    json["memory_usage_percent"] = memory_usage_percent;
-    json["estimated_power_mev"] = estimated_power_mev;
-    json["portal_duration_remaining_seconds"] = portal_duration_remaining_seconds;
-    
-    // We add timestamp for response correlation
-    auto now = std::chrono::system_clock::now();
-    auto time_t = std::chrono::system_clock::to_time_t(now);
-    std::stringstream timestamp_ss;
-    timestamp_ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
-    json["timestamp"] = timestamp_ss.str();
-    
-    return json;
+  Json::Value json;
+  json["uptime_seconds"] = static_cast<Json::Int64>(uptime_seconds);
+  json["total_fission_events"] =
+      static_cast<Json::UInt64>(total_fission_events);
+  json["total_energy_simulated_mev"] = total_energy_simulated_mev;
+  json["active_energy_fields"] = static_cast<Json::Int64>(active_energy_fields);
+  json["peak_memory_usage_bytes"] =
+      static_cast<Json::UInt64>(peak_memory_usage_bytes);
+  json["average_calculation_time_microseconds"] =
+      average_calc_time_microseconds;
+  json["total_calculations"] = static_cast<Json::UInt64>(total_calculations);
+  json["simulation_running"] = simulation_running;
+  json["cpu_usage_percent"] = cpu_usage_percent;
+  json["memory_usage_percent"] = memory_usage_percent;
+  json["estimated_power_mev"] = estimated_power_mev;
+  json["portal_duration_remaining_seconds"] = portal_duration_remaining_seconds;
+
+  // We add timestamp for response correlation
+  auto now = std::chrono::system_clock::now();
+  auto time_t = std::chrono::system_clock::to_time_t(now);
+  std::stringstream timestamp_ss;
+  timestamp_ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
+  json["timestamp"] = timestamp_ss.str();
+
+  return json;
 }
 
 // =============================================================================
@@ -174,7 +189,7 @@ Json::Value SystemStatusResponse::toJson() const {
  * This method tracks all incoming HTTP requests for monitoring
  */
 void HTTPServerMetrics::incrementRequests() {
-    total_requests.fetch_add(1, std::memory_order_relaxed);
+  total_requests.fetch_add(1, std::memory_order_relaxed);
 }
 
 /**
@@ -182,7 +197,7 @@ void HTTPServerMetrics::incrementRequests() {
  * This method tracks successful HTTP responses for monitoring
  */
 void HTTPServerMetrics::incrementSuccessful() {
-    successful_requests.fetch_add(1, std::memory_order_relaxed);
+  successful_requests.fetch_add(1, std::memory_order_relaxed);
 }
 
 /**
@@ -190,17 +205,18 @@ void HTTPServerMetrics::incrementSuccessful() {
  * This method tracks failed HTTP responses for monitoring
  */
 void HTTPServerMetrics::incrementErrors() {
-    error_requests.fetch_add(1, std::memory_order_relaxed);
+  error_requests.fetch_add(1, std::memory_order_relaxed);
 }
 
 /**
  * We update average response time with exponential moving average
- * This method maintains running average response time for performance monitoring
+ * This method maintains running average response time for performance
+ * monitoring
  */
 void HTTPServerMetrics::updateResponseTime(double time_ms) {
-    double current_avg = average_response_time.load(std::memory_order_relaxed);
-    double new_avg = (current_avg * 0.9) + (time_ms * 0.1); // EMA with alpha=0.1
-    average_response_time.store(new_avg, std::memory_order_relaxed);
+  double current_avg = average_response_time.load(std::memory_order_relaxed);
+  double new_avg = (current_avg * 0.9) + (time_ms * 0.1); // EMA with alpha=0.1
+  average_response_time.store(new_avg, std::memory_order_relaxed);
 }
 
 /**
@@ -208,7 +224,7 @@ void HTTPServerMetrics::updateResponseTime(double time_ms) {
  * This method tracks active HTTP connections for monitoring
  */
 void HTTPServerMetrics::incrementConnections() {
-    active_connections.fetch_add(1, std::memory_order_relaxed);
+  active_connections.fetch_add(1, std::memory_order_relaxed);
 }
 
 /**
@@ -216,7 +232,7 @@ void HTTPServerMetrics::incrementConnections() {
  * This method tracks connection closures for monitoring
  */
 void HTTPServerMetrics::decrementConnections() {
-    active_connections.fetch_sub(1, std::memory_order_relaxed);
+  active_connections.fetch_sub(1, std::memory_order_relaxed);
 }
 
 // =============================================================================
@@ -227,29 +243,28 @@ void HTTPServerMetrics::decrementConnections() {
  * We construct the HTTP server with configuration manager
  * The constructor initializes all server components and prepares for operation
  */
-HTTPTernaryFissionServer::HTTPTernaryFissionServer(std::unique_ptr<ConfigurationManager> config_manager)
-    : config_manager_(std::move(config_manager))
-    , http_server_(nullptr)
+HTTPTernaryFissionServer::HTTPTernaryFissionServer(
+    std::unique_ptr<ConfigurationManager> config_manager)
+    : config_manager_(std::move(config_manager)), http_server_(nullptr)
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    , https_server_(nullptr)
+      ,
+      https_server_(nullptr)
 #endif
-    , simulation_engine_(nullptr)
-    , bind_ip_("127.0.0.1")
-    , bind_port_(8333)
-    , ssl_enabled_(false)
-    , server_running_(false)
-    , start_time_(std::chrono::system_clock::now())
-    , field_id_counter_(1)
-    , websocket_broadcasting_(false)
-    , metrics_(std::make_unique<HTTPServerMetrics>())
-    , metrics_collecting_(false) {
-    
-    // We initialize SSL library for certificate handling
-    SSL_library_init();
-    SSL_load_error_strings();
-    OpenSSL_add_all_algorithms();
-    
-    std::cout << "HTTP Ternary Fission Server initialized with configuration" << std::endl;
+      ,
+      simulation_engine_(nullptr), bind_ip_("127.0.0.1"), bind_port_(8333),
+      ssl_enabled_(false), server_running_(false),
+      start_time_(std::chrono::system_clock::now()), field_id_counter_(1),
+      websocket_broadcasting_(false),
+      metrics_(std::make_unique<HTTPServerMetrics>()),
+      metrics_collecting_(false) {
+
+  // We initialize SSL library for certificate handling
+  SSL_library_init();
+  SSL_load_error_strings();
+  OpenSSL_add_all_algorithms();
+
+  std::cout << "HTTP Ternary Fission Server initialized with configuration"
+            << std::endl;
 }
 
 /**
@@ -257,15 +272,16 @@ HTTPTernaryFissionServer::HTTPTernaryFissionServer(std::unique_ptr<Configuration
  * The destructor ensures all resources are properly released
  */
 HTTPTernaryFissionServer::~HTTPTernaryFissionServer() {
-    if (server_running_) {
-        stop();
-    }
-    
-    // We cleanup SSL resources
-    EVP_cleanup();
-    ERR_free_strings();
-    
-    std::cout << "HTTP Ternary Fission Server destroyed and cleaned up" << std::endl;
+  if (server_running_) {
+    stop();
+  }
+
+  // We cleanup SSL resources
+  EVP_cleanup();
+  ERR_free_strings();
+
+  std::cout << "HTTP Ternary Fission Server destroyed and cleaned up"
+            << std::endl;
 }
 
 /**
@@ -273,127 +289,139 @@ HTTPTernaryFissionServer::~HTTPTernaryFissionServer() {
  * This method prepares all server components for operation
  */
 bool HTTPTernaryFissionServer::initialize() {
-    if (!config_manager_) {
-        std::cerr << "Error: Configuration manager not available for HTTP server" << std::endl;
-        return false;
-    }
-    
-    // We load network configuration from config manager
-    auto network_config = config_manager_->getNetworkConfig();
-    bind_ip_ = network_config.bind_ip;
-    bind_port_ = network_config.bind_port;
-    ssl_enabled_ = network_config.enable_ssl;
+  if (!config_manager_) {
+    std::cerr << "Error: Configuration manager not available for HTTP server"
+              << std::endl;
+    return false;
+  }
 
-    // We setup media streaming manager if enabled
-    auto media_config = config_manager_->getMediaStreamingConfig();
-    if (media_config.media_streaming_enabled) {
-        media_streaming_manager_ = std::make_unique<MediaStreamingManager>(media_config.media_root, media_config.icecast_mount);
-    }
-    
-    std::cout << "HTTP server configured for " << bind_ip_ << ":" << bind_port_ 
-              << (ssl_enabled_ ? " (HTTPS)" : " (HTTP)") << std::endl;
-    
-    // We initialize appropriate server type based on SSL configuration
+  // We load network configuration from config manager
+  auto network_config = config_manager_->getNetworkConfig();
+  bind_ip_ = network_config.bind_ip;
+  bind_port_ = network_config.bind_port;
+  ssl_enabled_ = network_config.enable_ssl;
+
+  // We setup media streaming manager if enabled
+  auto media_config = config_manager_->getMediaStreamingConfig();
+  if (media_config.media_streaming_enabled) {
+    media_streaming_manager_ = std::make_unique<MediaStreamingManager>(
+        media_config.media_root, media_config.icecast_mount);
+  }
+
+  std::cout << "HTTP server configured for " << bind_ip_ << ":" << bind_port_
+            << (ssl_enabled_ ? " (HTTPS)" : " (HTTP)") << std::endl;
+
+  // We initialize appropriate server type based on SSL configuration
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    if (ssl_enabled_) {
-        if (!loadSSLCertificates()) {
-            std::cerr << "Error: Failed to load SSL certificates, falling back to HTTP" << std::endl;
-            ssl_enabled_ = false;
-        } else {
-            setupSSLServer();
-        }
+  if (ssl_enabled_) {
+    if (!loadSSLCertificates()) {
+      std::cerr
+          << "Error: Failed to load SSL certificates, falling back to HTTP"
+          << std::endl;
+      ssl_enabled_ = false;
+    } else {
+      setupSSLServer();
     }
+  }
 #else
-    if (ssl_enabled_) {
-        std::cerr << "Warning: SSL support not available, falling back to HTTP" << std::endl;
-        ssl_enabled_ = false;
-    }
+  if (ssl_enabled_) {
+    std::cerr << "Warning: SSL support not available, falling back to HTTP"
+              << std::endl;
+    ssl_enabled_ = false;
+  }
 #endif
 
-    if (!ssl_enabled_) {
-        http_server_ = std::make_unique<httplib::Server>();
-    }
+  if (!ssl_enabled_) {
+    http_server_ = std::make_unique<httplib::Server>();
+  }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    auto server = ssl_enabled_ ?
-        static_cast<httplib::Server*>(https_server_.get()) :
-        static_cast<httplib::Server*>(http_server_.get());
+  auto server = ssl_enabled_
+                    ? static_cast<httplib::Server *>(https_server_.get())
+                    : static_cast<httplib::Server *>(http_server_.get());
 #else
-    auto server = static_cast<httplib::Server*>(http_server_.get());
+  auto server = static_cast<httplib::Server *>(http_server_.get());
 #endif
 
-    if (server) {
-        server->set_mount_point("/", network_config.web_root);
-        server->set_file_extension_and_mimetype_mapping("html", "text/html");
-        server->set_file_extension_and_mimetype_mapping("css", "text/css");
-        server->set_file_extension_and_mimetype_mapping("js", "application/javascript");
-        server->set_file_extension_and_mimetype_mapping("json", "application/json");
-        server->set_file_extension_and_mimetype_mapping("mp3", "audio/mpeg");
-        server->set_file_extension_and_mimetype_mapping("ogg", "audio/ogg");
-        server->set_file_extension_and_mimetype_mapping("oga", "audio/ogg");
-        server->set_file_extension_and_mimetype_mapping("aac", "audio/aac");
-        server->set_file_extension_and_mimetype_mapping("flac", "audio/flac");
-        server->set_file_extension_and_mimetype_mapping("opus", "audio/opus");
-        server->set_file_extension_and_mimetype_mapping("mp4", "video/mp4");
-        server->set_file_extension_and_mimetype_mapping("ogv", "video/ogg");
-        server->set_file_extension_and_mimetype_mapping("webm", "video/webm");
-        server->set_file_extension_and_mimetype_mapping("weba", "audio/webm");
-        server->set_file_extension_and_mimetype_mapping("m3u", "audio/x-mpegurl");
-        server->set_file_extension_and_mimetype_mapping("pls", "audio/x-scpls");
-        server->set_file_extension_and_mimetype_mapping("png", "image/png");
-        server->set_file_extension_and_mimetype_mapping("jpg", "image/jpeg");
-        server->set_file_extension_and_mimetype_mapping("jpeg", "image/jpeg");
-        server->set_file_extension_and_mimetype_mapping("gif", "image/gif");
-        server->set_file_extension_and_mimetype_mapping("svg", "image/svg+xml");
-    }
+  if (server) {
+    server->set_mount_point("/", network_config.web_root);
+    server->set_file_extension_and_mimetype_mapping("html", "text/html");
+    server->set_file_extension_and_mimetype_mapping("css", "text/css");
+    server->set_file_extension_and_mimetype_mapping("js",
+                                                    "application/javascript");
+    server->set_file_extension_and_mimetype_mapping("json", "application/json");
+    server->set_file_extension_and_mimetype_mapping("mp3", "audio/mpeg");
+    server->set_file_extension_and_mimetype_mapping("ogg", "audio/ogg");
+    server->set_file_extension_and_mimetype_mapping("oga", "audio/ogg");
+    server->set_file_extension_and_mimetype_mapping("aac", "audio/aac");
+    server->set_file_extension_and_mimetype_mapping("flac", "audio/flac");
+    server->set_file_extension_and_mimetype_mapping("opus", "audio/opus");
+    server->set_file_extension_and_mimetype_mapping("mp4", "video/mp4");
+    server->set_file_extension_and_mimetype_mapping("ogv", "video/ogg");
+    server->set_file_extension_and_mimetype_mapping("webm", "video/webm");
+    server->set_file_extension_and_mimetype_mapping("weba", "audio/webm");
+    server->set_file_extension_and_mimetype_mapping("m3u", "audio/x-mpegurl");
+    server->set_file_extension_and_mimetype_mapping("pls", "audio/x-scpls");
+    server->set_file_extension_and_mimetype_mapping("png", "image/png");
+    server->set_file_extension_and_mimetype_mapping("jpg", "image/jpeg");
+    server->set_file_extension_and_mimetype_mapping("jpeg", "image/jpeg");
+    server->set_file_extension_and_mimetype_mapping("gif", "image/gif");
+    server->set_file_extension_and_mimetype_mapping("svg", "image/svg+xml");
+  }
 
-    // We setup middleware and endpoints
-    setupMiddleware();
-    setupAPIEndpoints();
-    setupWebSocketEndpoints();
-    
-    // We initialize physics engine integration
-    if (!initializePhysicsEngine()) {
-        std::cerr << "Warning: Physics engine integration failed, API will return mock data" << std::endl;
-    }
-    
-    return true;
+  // We setup middleware and endpoints
+  setupMiddleware();
+  setupAPIEndpoints();
+  setupWebSocketEndpoints();
+
+  // We initialize physics engine integration
+  if (!initializePhysicsEngine()) {
+    std::cerr << "Warning: Physics engine integration failed, API will return "
+                 "mock data"
+              << std::endl;
+  }
+
+  return true;
 }
 
 /**
  * We start the HTTP server and begin accepting connections
- * This method starts the server in either HTTP or HTTPS mode based on configuration
+ * This method starts the server in either HTTP or HTTPS mode based on
+ * configuration
  */
 bool HTTPTernaryFissionServer::start() {
-    if (server_running_) {
-        std::cerr << "Error: HTTP server is already running" << std::endl;
-        return false;
-    }
-    
-    // We start metrics collection thread
-    metrics_collecting_ = true;
-    metrics_collection_thread_ = std::thread(&HTTPTernaryFissionServer::collectMetrics, this);
-    
-    // We start WebSocket broadcasting thread
-    websocket_broadcasting_ = true;
-    websocket_broadcast_thread_ = std::thread(&HTTPTernaryFissionServer::broadcastWebSocketUpdates, this);
-    
-    server_running_ = true;
-    start_time_ = std::chrono::system_clock::now();
-    
-    std::cout << "Starting HTTP server on " << bind_ip_ << ":" << bind_port_ << std::endl;
-    
-    // We start appropriate server type
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    if (ssl_enabled_ && https_server_) {
-        return https_server_->listen(bind_ip_, bind_port_);
-    } else
-#endif
-    if (http_server_) {
-        return http_server_->listen(bind_ip_, bind_port_);
-    }
-    
+  if (server_running_) {
+    std::cerr << "Error: HTTP server is already running" << std::endl;
     return false;
+  }
+
+  // We start metrics collection thread
+  metrics_collecting_ = true;
+  metrics_collection_thread_ =
+      std::thread(&HTTPTernaryFissionServer::collectMetrics, this);
+
+  // We start WebSocket broadcasting thread
+  websocket_broadcasting_ = true;
+  websocket_broadcast_thread_ =
+      std::thread(&HTTPTernaryFissionServer::broadcastWebSocketUpdates, this);
+
+  server_running_ = true;
+  start_time_ = std::chrono::system_clock::now();
+
+  std::cout << "Starting HTTP server on " << bind_ip_ << ":" << bind_port_
+            << std::endl;
+
+  // We start appropriate server type
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  if (ssl_enabled_ && https_server_) {
+    return https_server_->listen(bind_ip_, bind_port_);
+  } else
+#endif
+      if (http_server_) {
+    return http_server_->listen(bind_ip_, bind_port_);
+  }
+
+  return false;
 }
 
 /**
@@ -401,80 +429,80 @@ bool HTTPTernaryFissionServer::start() {
  * This method ensures proper cleanup of all server resources
  */
 void HTTPTernaryFissionServer::stop() {
-    if (!server_running_) {
-        return;
-    }
-    
-    std::cout << "Stopping HTTP server..." << std::endl;
-    
-    server_running_ = false;
-    
-    // We stop the appropriate server
+  if (!server_running_) {
+    return;
+  }
+
+  std::cout << "Stopping HTTP server..." << std::endl;
+
+  server_running_ = false;
+
+  // We stop the appropriate server
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    if (ssl_enabled_ && https_server_) {
-        https_server_->stop();
-    } else
+  if (ssl_enabled_ && https_server_) {
+    https_server_->stop();
+  } else
 #endif
-    if (http_server_) {
-        http_server_->stop();
-    }
-    
-    // We stop background threads
-    metrics_collecting_ = false;
-    if (metrics_collection_thread_.joinable()) {
-        metrics_collection_thread_.join();
-    }
-    
-    websocket_broadcasting_ = false;
-    if (websocket_broadcast_thread_.joinable()) {
-        websocket_broadcast_thread_.join();
-    }
-    
-    // We cleanup WebSocket connections
-    cleanupWebSocketConnections();
+      if (http_server_) {
+    http_server_->stop();
+  }
 
-    // We shutdown physics engine integration
-    shutdownPhysicsEngine();
+  // We stop background threads
+  metrics_collecting_ = false;
+  if (metrics_collection_thread_.joinable()) {
+    metrics_collection_thread_.join();
+  }
 
-    // We stop media streaming if active
-    if (media_streaming_manager_) {
-        media_streaming_manager_->stopStreaming();
-    }
-    
-    std::cout << "HTTP server stopped successfully" << std::endl;
+  websocket_broadcasting_ = false;
+  if (websocket_broadcast_thread_.joinable()) {
+    websocket_broadcast_thread_.join();
+  }
+
+  // We cleanup WebSocket connections
+  cleanupWebSocketConnections();
+
+  // We shutdown physics engine integration
+  shutdownPhysicsEngine();
+
+  // We stop media streaming if active
+  if (media_streaming_manager_) {
+    media_streaming_manager_->stopStreaming();
+  }
+
+  std::cout << "HTTP server stopped successfully" << std::endl;
 }
 
 /**
  * We check if the server is currently running
  * This method returns the current operational status
  */
-bool HTTPTernaryFissionServer::isRunning() const {
-    return server_running_;
-}
+bool HTTPTernaryFissionServer::isRunning() const { return server_running_; }
 
 /**
  * We get the server's current binding address
  * This method returns the IP:port combination the server is bound to
  */
 std::string HTTPTernaryFissionServer::getBindAddress() const {
-    return bind_ip_ + ":" + std::to_string(bind_port_);
+  return bind_ip_ + ":" + std::to_string(bind_port_);
 }
 
 /**
  * We set the physics simulation engine for API integration
  * This method configures the physics engine for API endpoint processing
  */
-void HTTPTernaryFissionServer::setSimulationEngine(std::shared_ptr<TernaryFissionSimulationEngine> engine) {
-    simulation_engine_ = engine;
-    std::cout << "Physics simulation engine integrated with HTTP server" << std::endl;
+void HTTPTernaryFissionServer::setSimulationEngine(
+    std::shared_ptr<TernaryFissionSimulationEngine> engine) {
+  simulation_engine_ = engine;
+  std::cout << "Physics simulation engine integrated with HTTP server"
+            << std::endl;
 }
 
 /**
  * We get current server performance metrics
  * This method returns complete server statistics and performance data
  */
-const HTTPServerMetrics& HTTPTernaryFissionServer::getMetrics() const {
-    return *metrics_;
+const HTTPServerMetrics &HTTPTernaryFissionServer::getMetrics() const {
+  return *metrics_;
 }
 
 /**
@@ -482,7 +510,7 @@ const HTTPServerMetrics& HTTPTernaryFissionServer::getMetrics() const {
  * This method returns comprehensive system health and operational data
  */
 SystemStatusResponse HTTPTernaryFissionServer::getSystemStatus() const {
-    return generateSystemStatus();
+  return generateSystemStatus();
 }
 
 /**
@@ -491,92 +519,103 @@ SystemStatusResponse HTTPTernaryFissionServer::getSystemStatus() const {
  */
 void HTTPTernaryFissionServer::setupMiddleware() {
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    auto server = ssl_enabled_ ?
-        static_cast<httplib::Server*>(https_server_.get()) :
-        static_cast<httplib::Server*>(http_server_.get());
+  auto server = ssl_enabled_
+                    ? static_cast<httplib::Server *>(https_server_.get())
+                    : static_cast<httplib::Server *>(http_server_.get());
 #else
-    auto server = static_cast<httplib::Server*>(http_server_.get());
+  auto server = static_cast<httplib::Server *>(http_server_.get());
 #endif
-    
-    if (!server) return;
-    
-    // We setup pre-routing middleware
-    server->set_pre_routing_handler([this](const httplib::Request& req, httplib::Response& res) {
+
+  if (!server)
+    return;
+
+  // We setup pre-routing middleware
+  server->set_pre_routing_handler(
+      [this](const httplib::Request &req, httplib::Response &res) {
         if (req.path.find("..") != std::string::npos) {
-            res.status = 403;
-            return httplib::Server::HandlerResponse::Handled;
+          res.status = 403;
+          return httplib::Server::HandlerResponse::Handled;
         }
         this->corsMiddleware(req, res);
         this->loggingMiddleware(req, res);
         this->metricsMiddleware(req, res);
         return httplib::Server::HandlerResponse::Unhandled;
-    });
-    
-    // We setup error handler
-    server->set_error_handler([this](const httplib::Request& /*req*/, httplib::Response& res) {
+      });
+
+  // We setup error handler
+  server->set_error_handler(
+      [this](const httplib::Request & /*req*/, httplib::Response &res) {
         this->sendErrorResponse(res, 500, "Internal server error");
-    });
-    
-    std::cout << "HTTP server middleware configured" << std::endl;
+      });
+
+  std::cout << "HTTP server middleware configured" << std::endl;
 }
 
 /**
  * We implement CORS middleware for cross-origin request support
  * This method adds appropriate CORS headers to all responses
  */
-void HTTPTernaryFissionServer::corsMiddleware(const httplib::Request& req, httplib::Response& res) {
-    auto network_config = config_manager_->getNetworkConfig();
-    
-    if (network_config.enable_cors) {
-        // We set CORS headers based on configuration
-        if (network_config.cors_origins.size() == 1 && network_config.cors_origins[0] == "*") {
-            res.set_header("Access-Control-Allow-Origin", "*");
-        } else {
-            // We check if request origin is in allowed list
-            std::string origin = req.get_header_value("Origin");
-            for (const auto& allowed_origin : network_config.cors_origins) {
-                if (origin == allowed_origin) {
-                    res.set_header("Access-Control-Allow-Origin", origin);
-                    break;
-                }
-            }
+void HTTPTernaryFissionServer::corsMiddleware(const httplib::Request &req,
+                                              httplib::Response &res) {
+  auto network_config = config_manager_->getNetworkConfig();
+
+  if (network_config.enable_cors) {
+    // We set CORS headers based on configuration
+    if (network_config.cors_origins.size() == 1 &&
+        network_config.cors_origins[0] == "*") {
+      res.set_header("Access-Control-Allow-Origin", "*");
+    } else {
+      // We check if request origin is in allowed list
+      std::string origin = req.get_header_value("Origin");
+      for (const auto &allowed_origin : network_config.cors_origins) {
+        if (origin == allowed_origin) {
+          res.set_header("Access-Control-Allow-Origin", origin);
+          break;
         }
-        
-        res.set_header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-        res.set_header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With");
-        res.set_header("Access-Control-Max-Age", "3600");
+      }
     }
+
+    res.set_header("Access-Control-Allow-Methods",
+                   "GET, POST, PUT, DELETE, OPTIONS");
+    res.set_header("Access-Control-Allow-Headers",
+                   "Content-Type, Authorization, X-Requested-With");
+    res.set_header("Access-Control-Max-Age", "3600");
+  }
 }
 
 /**
  * We implement logging middleware for request tracking
  * This method logs all HTTP requests with timing information
  */
-void HTTPTernaryFissionServer::loggingMiddleware(const httplib::Request& req, httplib::Response& /*res*/) {
-    auto start_time = std::chrono::steady_clock::now();
+void HTTPTernaryFissionServer::loggingMiddleware(const httplib::Request &req,
+                                                 httplib::Response & /*res*/) {
+  auto start_time = std::chrono::steady_clock::now();
 
-    // We log request details
-    std::time_t now = std::time(nullptr);
-    std::cout << "[" << std::put_time(std::localtime(&now), "%Y-%m-%d %H:%M:%S") << "] "
-              << req.method << " " << req.path << " from " << req.remote_addr << std::endl;
+  // We log request details
+  std::time_t now = std::time(nullptr);
+  std::cout << "[" << std::put_time(std::localtime(&now), "%Y-%m-%d %H:%M:%S")
+            << "] " << req.method << " " << req.path << " from "
+            << req.remote_addr << std::endl;
 
-    // We calculate response time when response is sent
-    auto end_time = std::chrono::steady_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
-    
-    metrics_->updateResponseTime(static_cast<double>(duration.count()));
+  // We calculate response time when response is sent
+  auto end_time = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      end_time - start_time);
+
+  metrics_->updateResponseTime(static_cast<double>(duration.count()));
 }
 
 /**
  * We implement metrics middleware for performance tracking
  * This method collects performance statistics for all requests
  */
-void HTTPTernaryFissionServer::metricsMiddleware(const httplib::Request& req, httplib::Response& /*res*/) {
-    metrics_->incrementRequests();
-    
-    // We track endpoint-specific metrics
-    std::lock_guard<std::mutex> lock(metrics_->metrics_mutex);
-    metrics_->endpoint_counters[req.path]++;
+void HTTPTernaryFissionServer::metricsMiddleware(const httplib::Request &req,
+                                                 httplib::Response & /*res*/) {
+  metrics_->incrementRequests();
+
+  // We track endpoint-specific metrics
+  std::lock_guard<std::mutex> lock(metrics_->metrics_mutex);
+  metrics_->endpoint_counters[req.path]++;
 }
 
 /**
@@ -585,203 +624,227 @@ void HTTPTernaryFissionServer::metricsMiddleware(const httplib::Request& req, ht
  */
 void HTTPTernaryFissionServer::setupAPIEndpoints() {
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    auto server = ssl_enabled_ ?
-        static_cast<httplib::Server*>(https_server_.get()) :
-        static_cast<httplib::Server*>(http_server_.get());
+  auto server = ssl_enabled_
+                    ? static_cast<httplib::Server *>(https_server_.get())
+                    : static_cast<httplib::Server *>(http_server_.get());
 #else
-    auto server = static_cast<httplib::Server*>(http_server_.get());
+  auto server = static_cast<httplib::Server *>(http_server_.get());
 #endif
-    
-    if (!server) return;
-    
-    // We setup health and status endpoints
-    server->Get("/api/v1/health", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleHealthCheck(req, res);
-    });
-    
-    server->Get("/api/v1/status", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleSystemStatus(req, res);
-    });
-    
-    // We setup energy fields endpoints
-    server->Get("/api/v1/energy-fields", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleEnergyFieldsList(req, res);
-    });
-    
-    server->Post("/api/v1/energy-fields", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleEnergyFieldCreate(req, res);
-    });
-    
-    server->Get(R"(/api/v1/energy-fields/([^/]+))", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleEnergyFieldGet(req, res);
-    });
-    
-    server->Put(R"(/api/v1/energy-fields/([^/]+))", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleEnergyFieldUpdate(req, res);
-    });
-    
-    server->Delete(R"(/api/v1/energy-fields/([^/]+))", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleEnergyFieldDelete(req, res);
-    });
-    
-    // We setup simulation control endpoints
-    server->Post("/api/v1/simulation/start", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleSimulationStart(req, res);
-    });
-    
-    server->Post("/api/v1/simulation/stop", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleSimulationStop(req, res);
-    });
-    
-    server->Post("/api/v1/simulation/reset", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleSimulationReset(req, res);
-    });
 
-    server->Put("/api/v1/portal/trigger", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handlePortalTrigger(req, res);
-    });
+  if (!server)
+    return;
 
-    // We setup media streaming control endpoints
-    server->Post("/api/v1/stream/start", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleStreamStart(req, res);
-    });
+  // We setup health and status endpoints
+  server->Get("/api/v1/health",
+              [this](const httplib::Request &req, httplib::Response &res) {
+                this->handleHealthCheck(req, res);
+              });
 
-    server->Post("/api/v1/stream/stop", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleStreamStop(req, res);
-    });
+  server->Get("/api/v1/status",
+              [this](const httplib::Request &req, httplib::Response &res) {
+                this->handleSystemStatus(req, res);
+              });
 
-    // We setup physics calculation endpoints
-    server->Post("/api/v1/physics/fission", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleFissionCalculation(req, res);
-    });
-    
-    server->Post("/api/v1/physics/conservation", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleConservationLaws(req, res);
-    });
-    
-    server->Post("/api/v1/physics/energy", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleEnergyGeneration(req, res);
-    });
-    
-    server->Get("/api/v1/statistics/fields", [this](const httplib::Request& req, httplib::Response& res) {
-        this->handleFieldStatistics(req, res);
-    });
-    
-    // We setup OPTIONS handler for CORS preflight
-    server->Options(".*", [this](const httplib::Request& req, httplib::Response& res) {
-        this->corsMiddleware(req, res);
-        res.status = 200;
-    });
-    
-    std::cout << "HTTP server API endpoints configured" << std::endl;
+  // We setup energy fields endpoints
+  server->Get("/api/v1/energy-fields",
+              [this](const httplib::Request &req, httplib::Response &res) {
+                this->handleEnergyFieldsList(req, res);
+              });
+
+  server->Post("/api/v1/energy-fields",
+               [this](const httplib::Request &req, httplib::Response &res) {
+                 this->handleEnergyFieldCreate(req, res);
+               });
+
+  server->Get(R"(/api/v1/energy-fields/([^/]+))",
+              [this](const httplib::Request &req, httplib::Response &res) {
+                this->handleEnergyFieldGet(req, res);
+              });
+
+  server->Put(R"(/api/v1/energy-fields/([^/]+))",
+              [this](const httplib::Request &req, httplib::Response &res) {
+                this->handleEnergyFieldUpdate(req, res);
+              });
+
+  server->Delete(R"(/api/v1/energy-fields/([^/]+))",
+                 [this](const httplib::Request &req, httplib::Response &res) {
+                   this->handleEnergyFieldDelete(req, res);
+                 });
+
+  // We setup simulation control endpoints
+  server->Post("/api/v1/simulation/start",
+               [this](const httplib::Request &req, httplib::Response &res) {
+                 this->handleSimulationStart(req, res);
+               });
+
+  server->Post("/api/v1/simulation/stop",
+               [this](const httplib::Request &req, httplib::Response &res) {
+                 this->handleSimulationStop(req, res);
+               });
+
+  server->Post("/api/v1/simulation/reset",
+               [this](const httplib::Request &req, httplib::Response &res) {
+                 this->handleSimulationReset(req, res);
+               });
+
+  server->Put("/api/v1/portal/trigger",
+              [this](const httplib::Request &req, httplib::Response &res) {
+                this->handlePortalTrigger(req, res);
+              });
+
+  // We setup media streaming control endpoints
+  server->Post("/api/v1/stream/start",
+               [this](const httplib::Request &req, httplib::Response &res) {
+                 this->handleStreamStart(req, res);
+               });
+
+  server->Post("/api/v1/stream/stop",
+               [this](const httplib::Request &req, httplib::Response &res) {
+                 this->handleStreamStop(req, res);
+               });
+
+  // We setup physics calculation endpoints
+  server->Post("/api/v1/physics/fission",
+               [this](const httplib::Request &req, httplib::Response &res) {
+                 this->handleFissionCalculation(req, res);
+               });
+
+  server->Post("/api/v1/physics/conservation",
+               [this](const httplib::Request &req, httplib::Response &res) {
+                 this->handleConservationLaws(req, res);
+               });
+
+  server->Post("/api/v1/physics/energy",
+               [this](const httplib::Request &req, httplib::Response &res) {
+                 this->handleEnergyGeneration(req, res);
+               });
+
+  server->Get("/api/v1/statistics/fields",
+              [this](const httplib::Request &req, httplib::Response &res) {
+                this->handleFieldStatistics(req, res);
+              });
+
+  // We setup OPTIONS handler for CORS preflight
+  server->Options(".*",
+                  [this](const httplib::Request &req, httplib::Response &res) {
+                    this->corsMiddleware(req, res);
+                    res.status = 200;
+                  });
+
+  std::cout << "HTTP server API endpoints configured" << std::endl;
 }
 
 /**
  * We handle health check endpoint requests
  * This method provides basic server health information for monitoring
  */
-void HTTPTernaryFissionServer::handleHealthCheck(const httplib::Request& /*req*/, httplib::Response& res) {
-    auto uptime = std::chrono::duration_cast<std::chrono::seconds>(
-        std::chrono::system_clock::now() - start_time_
-    );
-    
-    Json::Value health;
-    health["status"] = "healthy";
-    health["uptime_seconds"] = static_cast<Json::Int64>(uptime.count());
-    health["active_energy_fields"] = static_cast<Json::Int64>(energy_fields_.size());
-    health["simulation_running"] = simulation_engine_ != nullptr;
-    health["version"] = VERSION;
-    health["author"] = "bthlops (David StJ)";
-    
-    auto now = std::chrono::system_clock::now();
-    auto time_t = std::chrono::system_clock::to_time_t(now);
-    std::stringstream timestamp_ss;
-    timestamp_ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
-    health["timestamp"] = timestamp_ss.str();
-    
-    sendJSONResponse(res, 200, health);
-    metrics_->incrementSuccessful();
-    
-    std::cout << "Health check endpoint served successfully" << std::endl;
+void HTTPTernaryFissionServer::handleHealthCheck(
+    const httplib::Request & /*req*/, httplib::Response &res) {
+  auto uptime = std::chrono::duration_cast<std::chrono::seconds>(
+      std::chrono::system_clock::now() - start_time_);
+
+  Json::Value health;
+  health["status"] = "healthy";
+  health["uptime_seconds"] = static_cast<Json::Int64>(uptime.count());
+  health["active_energy_fields"] =
+      static_cast<Json::Int64>(energy_fields_.size());
+  health["simulation_running"] = simulation_engine_ != nullptr;
+  health["version"] = VERSION;
+  health["author"] = "bthlops (David StJ)";
+
+  auto now = std::chrono::system_clock::now();
+  auto time_t = std::chrono::system_clock::to_time_t(now);
+  std::stringstream timestamp_ss;
+  timestamp_ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
+  health["timestamp"] = timestamp_ss.str();
+
+  sendJSONResponse(res, 200, health);
+  metrics_->incrementSuccessful();
+
+  std::cout << "Health check endpoint served successfully" << std::endl;
 }
 
 /**
  * We handle system status endpoint requests
  * This method provides comprehensive system status information
  */
-void HTTPTernaryFissionServer::handleSystemStatus(const httplib::Request& /*req*/, httplib::Response& res) {
-    SystemStatusResponse status = generateSystemStatus();
-    sendJSONResponse(res, 200, status.toJson());
-    metrics_->incrementSuccessful();
-    
-    std::cout << "System status endpoint served successfully" << std::endl;
+void HTTPTernaryFissionServer::handleSystemStatus(
+    const httplib::Request & /*req*/, httplib::Response &res) {
+  SystemStatusResponse status = generateSystemStatus();
+  sendJSONResponse(res, 200, status.toJson());
+  metrics_->incrementSuccessful();
+
+  std::cout << "System status endpoint served successfully" << std::endl;
 }
 
 /**
  * We handle energy fields list endpoint requests
  * This method returns all active energy fields
  */
-void HTTPTernaryFissionServer::handleEnergyFieldsList(const httplib::Request& /*req*/, httplib::Response& res) {
-    std::lock_guard<std::mutex> lock(fields_mutex_);
-    
-    Json::Value fields_array(Json::arrayValue);
-    for (const auto& [field_id, field] : energy_fields_) {
-        fields_array.append(field->toJson());
-    }
-    
-    Json::Value response;
-    response["energy_fields"] = fields_array;
-    response["total_fields"] = static_cast<Json::Int64>(energy_fields_.size());
-    
-    sendJSONResponse(res, 200, response);
-    metrics_->incrementSuccessful();
-    
-    std::cout << "Energy fields list endpoint served successfully" << std::endl;
+void HTTPTernaryFissionServer::handleEnergyFieldsList(
+    const httplib::Request & /*req*/, httplib::Response &res) {
+  std::lock_guard<std::mutex> lock(fields_mutex_);
+
+  Json::Value fields_array(Json::arrayValue);
+  for (const auto &[field_id, field] : energy_fields_) {
+    fields_array.append(field->toJson());
+  }
+
+  Json::Value response;
+  response["energy_fields"] = fields_array;
+  response["total_fields"] = static_cast<Json::Int64>(energy_fields_.size());
+
+  sendJSONResponse(res, 200, response);
+  metrics_->incrementSuccessful();
+
+  std::cout << "Energy fields list endpoint served successfully" << std::endl;
 }
 
 /**
  * We handle energy field creation endpoint requests
  * This method creates new energy fields with specified parameters
  */
-void HTTPTernaryFissionServer::handleEnergyFieldCreate(const httplib::Request& req, httplib::Response& res) {
-    Json::Value request_json;
-    if (!parseJSONRequest(req, request_json)) {
-        sendErrorResponse(res, 400, "Invalid JSON request body");
-        metrics_->incrementErrors();
-        return;
-    }
-    
-    auto field = std::make_unique<EnergyFieldResponse>();
-    if (!field->fromJson(request_json)) {
-        sendErrorResponse(res, 400, "Invalid energy field parameters");
-        metrics_->incrementErrors();
-        return;
-    }
-    
-    // We generate unique field ID
-    field->field_id = generateFieldID();
-    field->created_at = std::chrono::system_clock::now();
-    field->last_updated = field->created_at;
-    field->status = "active";
-    field->active = true;
-    field->total_energy_mev = field->energy_level_mev;
-    
-    // We validate physics parameters
-    if (field->energy_level_mev < 0 || field->energy_level_mev > 1000000) {
-        sendErrorResponse(res, 400, "Energy level must be between 0 and 1,000,000 MeV");
-        metrics_->incrementErrors();
-        return;
-    }
-    
-    std::lock_guard<std::mutex> lock(fields_mutex_);
-    std::string field_id = field->field_id;
-    energy_fields_[field_id] = std::move(field);
-    
-    Json::Value response = energy_fields_[field_id]->toJson();
-    sendJSONResponse(res, 201, response);  
-    metrics_->incrementSuccessful();
-    
-    std::cout << "Energy field created successfully: " << field_id << std::endl;
+void HTTPTernaryFissionServer::handleEnergyFieldCreate(
+    const httplib::Request &req, httplib::Response &res) {
+  Json::Value request_json;
+  if (!parseJSONRequest(req, request_json)) {
+    sendErrorResponse(res, 400, "Invalid JSON request body");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  auto field = std::make_unique<EnergyFieldResponse>();
+  if (!field->fromJson(request_json)) {
+    sendErrorResponse(res, 400, "Invalid energy field parameters");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  // We generate unique field ID
+  field->field_id = generateFieldID();
+  field->created_at = std::chrono::system_clock::now();
+  field->last_updated = field->created_at;
+  field->status = "active";
+  field->active = true;
+  field->total_energy_mev = field->energy_level_mev;
+
+  // We validate physics parameters
+  if (field->energy_level_mev < 0 || field->energy_level_mev > 1000000) {
+    sendErrorResponse(res, 400,
+                      "Energy level must be between 0 and 1,000,000 MeV");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(fields_mutex_);
+  std::string field_id = field->field_id;
+  energy_fields_[field_id] = std::move(field);
+
+  Json::Value response = energy_fields_[field_id]->toJson();
+  sendJSONResponse(res, 201, response);
+  metrics_->incrementSuccessful();
+
+  std::cout << "Energy field created successfully: " << field_id << std::endl;
 }
 
 /**
@@ -789,97 +852,100 @@ void HTTPTernaryFissionServer::handleEnergyFieldCreate(const httplib::Request& r
  * This method collects all system health and performance data
  */
 SystemStatusResponse HTTPTernaryFissionServer::generateSystemStatus() const {
-    SystemStatusResponse status;
-    
-    auto uptime = std::chrono::duration_cast<std::chrono::seconds>(
-        std::chrono::system_clock::now() - start_time_
-    );
-    status.uptime_seconds = uptime.count();
-    
-    // We get metrics data
-    status.active_energy_fields = static_cast<int>(energy_fields_.size());
-    
-    // We get simulation engine statistics if available
-    if (simulation_engine_) {
-        status.simulation_running = true;
-        // status.total_fission_events = simulation_engine_->getTotalFissionEvents();
-        // status.total_energy_simulated_mev = simulation_engine_->getTotalEnergySimulated();
-        // status.total_calculations = simulation_engine_->getTotalCalculations();
-        // status.average_calc_time_microseconds = simulation_engine_->getAverageCalculationTime();
-        simulation_engine_->getPortalEventState(status.estimated_power_mev,
-                                               status.portal_duration_remaining_seconds);
-    }
-    
-    // We calculate system resource usage
-    status.cpu_usage_percent = getCPUUsagePercent();
-    MemoryUsage mem = getMemoryUsage();
-    status.memory_usage_percent = mem.percent;
-    status.peak_memory_usage_bytes = mem.peak_bytes;
-    
-    return status;
+  SystemStatusResponse status;
+
+  auto uptime = std::chrono::duration_cast<std::chrono::seconds>(
+      std::chrono::system_clock::now() - start_time_);
+  status.uptime_seconds = uptime.count();
+
+  // We get metrics data
+  status.active_energy_fields = static_cast<int>(energy_fields_.size());
+
+  // We get simulation engine statistics if available
+  if (simulation_engine_) {
+    status.simulation_running = true;
+    // status.total_fission_events =
+    // simulation_engine_->getTotalFissionEvents();
+    // status.total_energy_simulated_mev =
+    // simulation_engine_->getTotalEnergySimulated(); status.total_calculations
+    // = simulation_engine_->getTotalCalculations();
+    // status.average_calc_time_microseconds =
+    // simulation_engine_->getAverageCalculationTime();
+    simulation_engine_->getPortalEventState(
+        status.estimated_power_mev, status.portal_duration_remaining_seconds);
+  }
+
+  // We calculate system resource usage
+  status.cpu_usage_percent = getCPUUsagePercent();
+  MemoryUsage mem = getMemoryUsage();
+  status.memory_usage_percent = mem.percent;
+  status.peak_memory_usage_bytes = mem.peak_bytes;
+
+  return status;
 }
 
 /**
  * We send JSON response with proper headers
  * This method handles JSON serialization and HTTP response formatting
  */
-void HTTPTernaryFissionServer::sendJSONResponse(httplib::Response& res, int status_code, const Json::Value& json) {
-    Json::StreamWriterBuilder builder;
-    builder["indentation"] = "  ";
-    std::string json_string = Json::writeString(builder, json);
-    
-    res.set_content(json_string, "application/json");
-    res.status = status_code;
-    res.set_header("Cache-Control", "no-cache");
+void HTTPTernaryFissionServer::sendJSONResponse(httplib::Response &res,
+                                                int status_code,
+                                                const Json::Value &json) {
+  Json::StreamWriterBuilder builder;
+  builder["indentation"] = "  ";
+  std::string json_string = Json::writeString(builder, json);
+
+  res.set_content(json_string, "application/json");
+  res.status = status_code;
+  res.set_header("Cache-Control", "no-cache");
 }
 
 /**
  * We send error response with standard format
  * This method handles error response formatting with proper HTTP status codes
  */
-void HTTPTernaryFissionServer::sendErrorResponse(httplib::Response& res, int status_code, const std::string& message) {
-    Json::Value error;
-    error["error"] = message;
-    error["status_code"] = static_cast<Json::Int64>(status_code);
-    
-    auto now = std::chrono::system_clock::now();
-    auto time_t = std::chrono::system_clock::to_time_t(now);
-    std::stringstream timestamp_ss;
-    timestamp_ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
-    error["timestamp"] = timestamp_ss.str();
-    
-    sendJSONResponse(res, status_code, error);
+void HTTPTernaryFissionServer::sendErrorResponse(httplib::Response &res,
+                                                 int status_code,
+                                                 const std::string &message) {
+  Json::Value error;
+  error["error"] = message;
+  error["status_code"] = static_cast<Json::Int64>(status_code);
+
+  auto now = std::chrono::system_clock::now();
+  auto time_t = std::chrono::system_clock::to_time_t(now);
+  std::stringstream timestamp_ss;
+  timestamp_ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
+  error["timestamp"] = timestamp_ss.str();
+
+  sendJSONResponse(res, status_code, error);
 }
 
 /**
  * We parse JSON request body with error handling
  * This method handles JSON parsing and validation for API requests
  */
-bool HTTPTernaryFissionServer::parseJSONRequest(const httplib::Request& req, Json::Value& json) {
-    try {
-        Json::CharReaderBuilder builder;
-        Json::CharReader* reader = builder.newCharReader();
-        std::string errors;
-        
-        bool success = reader->parse(
-            req.body.c_str(),
-            req.body.c_str() + req.body.length(),
-            &json,
-            &errors
-        );
-        
-        delete reader;
-        
-        if (!success) {
-            std::cerr << "JSON parsing error: " << errors << std::endl;
-            return false;
-        }
-        
-        return true;
-    } catch (const std::exception& e) {
-        std::cerr << "Exception during JSON parsing: " << e.what() << std::endl;
-        return false;
+bool HTTPTernaryFissionServer::parseJSONRequest(const httplib::Request &req,
+                                                Json::Value &json) {
+  try {
+    Json::CharReaderBuilder builder;
+    Json::CharReader *reader = builder.newCharReader();
+    std::string errors;
+
+    bool success = reader->parse(
+        req.body.c_str(), req.body.c_str() + req.body.length(), &json, &errors);
+
+    delete reader;
+
+    if (!success) {
+      std::cerr << "JSON parsing error: " << errors << std::endl;
+      return false;
     }
+
+    return true;
+  } catch (const std::exception &e) {
+    std::cerr << "Exception during JSON parsing: " << e.what() << std::endl;
+    return false;
+  }
 }
 
 /**
@@ -887,78 +953,82 @@ bool HTTPTernaryFissionServer::parseJSONRequest(const httplib::Request& req, Jso
  * This method creates unique identifiers for energy field instances
  */
 std::string HTTPTernaryFissionServer::generateFieldID() {
-    int64_t counter = field_id_counter_.fetch_add(1, std::memory_order_relaxed);
-    return "field_" + std::to_string(counter);
+  int64_t counter = field_id_counter_.fetch_add(1, std::memory_order_relaxed);
+  return "field_" + std::to_string(counter);
 }
 
 /**
- * We load SSL certificates for HTTPS operation
- * This method loads and validates SSL certificates from configuration paths
+ * We load SSL certificate chain and private key for HTTPS operation
+ * This method loads and validates TLS credentials from configuration paths
  */
 bool HTTPTernaryFissionServer::loadSSLCertificates() {
-    auto ssl_config = config_manager_->getSSLConfig();
-    
-    if (ssl_config.certificate_file.empty() || ssl_config.private_key_file.empty()) {
-        std::cerr << "SSL certificate or private key path not configured" << std::endl;
-        return false;
-    }
-    
-    // We validate certificate file exists and is readable
-    if (!validateSSLCertificate(ssl_config.certificate_file)) {
-        std::cerr << "SSL certificate validation failed" << std::endl;
-        return false;
-    }
-    
-    // We validate private key file exists
-    struct stat key_stat;
-    if (stat(ssl_config.private_key_file.c_str(), &key_stat) != 0) {
-        std::cerr << "SSL private key file not found: " << ssl_config.private_key_file << std::endl; 
-        return false;
-    }
-    
-    std::cout << "SSL certificates loaded successfully" << std::endl;
-    return true;
+  auto ssl_config = config_manager_->getSSLConfig();
+
+  if (ssl_config.certificate_file.empty() ||
+      ssl_config.private_key_file.empty()) {
+    std::cerr << "SSL certificate chain or private key path not configured"
+              << std::endl;
+    return false;
+  }
+
+  // We validate certificate file exists and is readable
+  if (!validateSSLCertificate(ssl_config.certificate_file)) {
+    std::cerr << "SSL certificate validation failed" << std::endl;
+    return false;
+  }
+
+  // We validate private key file exists
+  struct stat key_stat;
+  if (stat(ssl_config.private_key_file.c_str(), &key_stat) != 0) {
+    std::cerr << "SSL private key file not found: "
+              << ssl_config.private_key_file << std::endl;
+    return false;
+  }
+
+  std::cout << "SSL certificate chain loaded successfully" << std::endl;
+  return true;
 }
 
 /**
  * We validate SSL certificate file
  * This method checks certificate validity and accessibility
  */
-bool HTTPTernaryFissionServer::validateSSLCertificate(const std::string& cert_path) {
-    FILE* cert_file = fopen(cert_path.c_str(), "r");
-    if (!cert_file) {
-        std::cerr << "Cannot open SSL certificate file: " << cert_path << std::endl;
-        return false;
-    }
-    
-    X509* cert = PEM_read_X509(cert_file, nullptr, nullptr, nullptr);
-    fclose(cert_file);
-    
-    if (!cert) {
-        std::cerr << "Cannot parse SSL certificate: " << cert_path << std::endl;
-        return false;
-    }
-    
-    // We check certificate validity dates
-    ASN1_TIME* not_before = X509_get_notBefore(cert);
-    ASN1_TIME* not_after = X509_get_notAfter(cert);
-    
-    int day, sec;
-    if (ASN1_TIME_diff(&day, &sec, not_before, nullptr) <= 0) {
-        std::cerr << "SSL certificate is not yet valid" << std::endl;
-        X509_free(cert);
-        return false;
-    }
-    
-    if (ASN1_TIME_diff(&day, &sec, nullptr, not_after) <= 0) {
-        std::cerr << "SSL certificate has expired" << std::endl;
-        X509_free(cert);
-        return false;
-    }
-    
+bool HTTPTernaryFissionServer::validateSSLCertificate(
+    const std::string &cert_path) {
+  FILE *cert_file = fopen(cert_path.c_str(), "r");
+  if (!cert_file) {
+    std::cerr << "Cannot open SSL certificate file: " << cert_path << std::endl;
+    return false;
+  }
+
+  X509 *cert = PEM_read_X509(cert_file, nullptr, nullptr, nullptr);
+  fclose(cert_file);
+
+  if (!cert) {
+    std::cerr << "Cannot parse SSL certificate: " << cert_path << std::endl;
+    return false;
+  }
+
+  // We check certificate validity dates
+  ASN1_TIME *not_before = X509_get_notBefore(cert);
+  ASN1_TIME *not_after = X509_get_notAfter(cert);
+
+  int day, sec;
+  if (ASN1_TIME_diff(&day, &sec, not_before, nullptr) <= 0) {
+    std::cerr << "SSL certificate is not yet valid" << std::endl;
     X509_free(cert);
-    std::cout << "SSL certificate validation successful" << std::endl;
-    return true;
+    return false;
+  }
+
+  if (ASN1_TIME_diff(&day, &sec, nullptr, not_after) <= 0) {
+    std::cerr << "SSL certificate has expired" << std::endl;
+    X509_free(cert);
+    return false;
+  }
+
+  X509_free(cert);
+  std::cout << "SSL certificate validation successful" << std::endl;
+  return true;
 }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
@@ -967,21 +1037,19 @@ bool HTTPTernaryFissionServer::validateSSLCertificate(const std::string& cert_pa
  * This method configures HTTPS server with loaded certificates
  */
 void HTTPTernaryFissionServer::setupSSLServer() {
-    auto ssl_config = config_manager_->getSSLConfig();
-    
-    https_server_ = std::make_unique<httplib::SSLServer>(
-        ssl_config.certificate_file.c_str(),
-        ssl_config.private_key_file.c_str()
-    );
+  auto ssl_config = config_manager_->getSSLConfig();
 
-    if (!https_server_->is_valid()) {
-        std::cerr << "Failed to create SSL server with certificates" << std::endl;
-        https_server_.reset();
-        ssl_enabled_ = false;
-        return;
-    }
+  https_server_ = std::make_unique<httplib::SSLServer>(
+      ssl_config.certificate_file.c_str(), ssl_config.private_key_file.c_str());
 
-    std::cout << "HTTPS server configured with SSL certificates" << std::endl;
+  if (!https_server_->is_valid()) {
+    std::cerr << "Failed to create SSL server with certificates" << std::endl;
+    https_server_.reset();
+    ssl_enabled_ = false;
+    return;
+  }
+
+  std::cout << "HTTPS server configured with SSL certificates" << std::endl;
 }
 #endif
 
@@ -990,9 +1058,9 @@ void HTTPTernaryFissionServer::setupSSLServer() {
  * This method sets up communication with the physics simulation engine
  */
 bool HTTPTernaryFissionServer::initializePhysicsEngine() {
-    // Physics engine integration will be implemented when engine is available
-    std::cout << "Physics engine integration initialized" << std::endl;
-    return true;
+  // Physics engine integration will be implemented when engine is available
+  std::cout << "Physics engine integration initialized" << std::endl;
+  return true;
 }
 
 /**
@@ -1000,8 +1068,8 @@ bool HTTPTernaryFissionServer::initializePhysicsEngine() {
  * This method cleanly disconnects from the physics simulation engine
  */
 void HTTPTernaryFissionServer::shutdownPhysicsEngine() {
-    simulation_engine_.reset();
-    std::cout << "Physics engine integration shutdown" << std::endl;  
+  simulation_engine_.reset();
+  std::cout << "Physics engine integration shutdown" << std::endl;
 }
 
 /**
@@ -1009,8 +1077,9 @@ void HTTPTernaryFissionServer::shutdownPhysicsEngine() {
  * This method configures WebSocket handlers for live updates
  */
 void HTTPTernaryFissionServer::setupWebSocketEndpoints() {
-    // WebSocket implementation will be added in future enhancement
-    std::cout << "WebSocket endpoints configured for real-time monitoring" << std::endl;
+  // WebSocket implementation will be added in future enhancement
+  std::cout << "WebSocket endpoints configured for real-time monitoring"
+            << std::endl;
 }
 
 /**
@@ -1018,22 +1087,22 @@ void HTTPTernaryFissionServer::setupWebSocketEndpoints() {
  * This method sends real-time updates to all connected monitoring clients
  */
 void HTTPTernaryFissionServer::broadcastWebSocketUpdates() {
-    while (websocket_broadcasting_) {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+  while (websocket_broadcasting_) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 
-        // We broadcast system status to all connected clients
-        SystemStatusResponse status = generateSystemStatus();
+    // We broadcast system status to all connected clients
+    SystemStatusResponse status = generateSystemStatus();
 
-        Json::StreamWriterBuilder builder;
-        builder["indentation"] = "";
-        std::string message = Json::writeString(builder, status.toJson());
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "";
+    std::string message = Json::writeString(builder, status.toJson());
 
-        std::lock_guard<std::mutex> lock(websocket_mutex_);
-        for (auto& [id, connection] : websocket_connections_) {
-            std::lock_guard<std::mutex> qlock(connection->queue_mutex);
-            connection->message_queue.push(message);
-        }
+    std::lock_guard<std::mutex> lock(websocket_mutex_);
+    for (auto &[id, connection] : websocket_connections_) {
+      std::lock_guard<std::mutex> qlock(connection->queue_mutex);
+      connection->message_queue.push(message);
     }
+  }
 }
 
 /**
@@ -1041,9 +1110,9 @@ void HTTPTernaryFissionServer::broadcastWebSocketUpdates() {
  * This method closes all active WebSocket connections during shutdown
  */
 void HTTPTernaryFissionServer::cleanupWebSocketConnections() {
-    std::lock_guard<std::mutex> lock(websocket_mutex_);
-    websocket_connections_.clear();
-    std::cout << "WebSocket connections cleaned up" << std::endl;
+  std::lock_guard<std::mutex> lock(websocket_mutex_);
+  websocket_connections_.clear();
+  std::cout << "WebSocket connections cleaned up" << std::endl;
 }
 
 /**
@@ -1051,19 +1120,19 @@ void HTTPTernaryFissionServer::cleanupWebSocketConnections() {
  * This method runs in background thread to gather performance data
  */
 void HTTPTernaryFissionServer::collectMetrics() {
-    while (metrics_collecting_) {
-        std::this_thread::sleep_for(std::chrono::seconds(10));
-        
-        // We update field statistics
-        updateFieldStatistics();
-        
-        // We log current metrics periodically
-        if (config_manager_->getLoggingConfig().verbose_output) {
-            std::cout << "Metrics: " << metrics_->total_requests.load() 
-                      << " requests, " << metrics_->active_connections.load() 
-                      << " connections" << std::endl;
-        }
+  while (metrics_collecting_) {
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+
+    // We update field statistics
+    updateFieldStatistics();
+
+    // We log current metrics periodically
+    if (config_manager_->getLoggingConfig().verbose_output) {
+      std::cout << "Metrics: " << metrics_->total_requests.load()
+                << " requests, " << metrics_->active_connections.load()
+                << " connections" << std::endl;
     }
+  }
 }
 
 /**
@@ -1071,595 +1140,629 @@ void HTTPTernaryFissionServer::collectMetrics() {
  * This method recalculates field statistics for monitoring
  */
 void HTTPTernaryFissionServer::updateFieldStatistics() {
-    std::lock_guard<std::mutex> lock(fields_mutex_);
-    
-    // We update field timestamps and status
-    for (auto& [field_id, field] : energy_fields_) {
-        field->last_updated = std::chrono::system_clock::now();
+  std::lock_guard<std::mutex> lock(fields_mutex_);
 
-        // We synchronize boolean active state with status
-        field->active = (field->status == "active");
+  // We update field timestamps and status
+  for (auto &[field_id, field] : energy_fields_) {
+    field->last_updated = std::chrono::system_clock::now();
 
-        // We simulate field evolution for demonstration
-        if (field->status == "active") {
-            field->energy_level_mev *= (1.0 - field->dissipation_rate * 0.001);
-            field->entropy_factor += 0.001;
-            field->total_energy_mev += field->energy_level_mev;
-        }
+    // We synchronize boolean active state with status
+    field->active = (field->status == "active");
+
+    // We simulate field evolution for demonstration
+    if (field->status == "active") {
+      field->energy_level_mev *= (1.0 - field->dissipation_rate * 0.001);
+      field->entropy_factor += 0.001;
+      field->total_energy_mev += field->energy_level_mev;
     }
+  }
 }
 
 // We implement placeholder handlers for remaining endpoints
-void HTTPTernaryFissionServer::handleEnergyFieldGet(const httplib::Request& req, httplib::Response& res) {
-    std::string field_id = req.matches[1];
-    
-    std::lock_guard<std::mutex> lock(fields_mutex_);
-    auto it = energy_fields_.find(field_id);
-    
-    if (it == energy_fields_.end()) {
-        sendErrorResponse(res, 404, "Energy field not found");
-        metrics_->incrementErrors();
-        return;
-    }
-    
-    sendJSONResponse(res, 200, it->second->toJson());
-    metrics_->incrementSuccessful();
+void HTTPTernaryFissionServer::handleEnergyFieldGet(const httplib::Request &req,
+                                                    httplib::Response &res) {
+  std::string field_id = req.matches[1];
+
+  std::lock_guard<std::mutex> lock(fields_mutex_);
+  auto it = energy_fields_.find(field_id);
+
+  if (it == energy_fields_.end()) {
+    sendErrorResponse(res, 404, "Energy field not found");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  sendJSONResponse(res, 200, it->second->toJson());
+  metrics_->incrementSuccessful();
 }
 
-void HTTPTernaryFissionServer::handleEnergyFieldUpdate(const httplib::Request& req, httplib::Response& res) {
-    std::string field_id = req.matches[1];
+void HTTPTernaryFissionServer::handleEnergyFieldUpdate(
+    const httplib::Request &req, httplib::Response &res) {
+  std::string field_id = req.matches[1];
 
-    Json::Value request_json;
-    if (!parseJSONRequest(req, request_json)) {
-        sendErrorResponse(res, 400, "Invalid JSON request body");
-        metrics_->incrementErrors();
-        return;
+  Json::Value request_json;
+  if (!parseJSONRequest(req, request_json)) {
+    sendErrorResponse(res, 400, "Invalid JSON request body");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(fields_mutex_);
+  auto it = energy_fields_.find(field_id);
+  if (it == energy_fields_.end()) {
+    sendErrorResponse(res, 404, "Energy field not found");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  EnergyFieldResponse *field = it->second.get();
+  bool updated = false;
+
+  // Validate and update provided fields
+  if (request_json.isMember("energy_level_mev")) {
+    if (!request_json["energy_level_mev"].isNumeric()) {
+      sendErrorResponse(res, 400, "energy_level_mev must be numeric");
+      metrics_->incrementErrors();
+      return;
     }
-
-    std::lock_guard<std::mutex> lock(fields_mutex_);
-    auto it = energy_fields_.find(field_id);
-    if (it == energy_fields_.end()) {
-        sendErrorResponse(res, 404, "Energy field not found");
-        metrics_->incrementErrors();
-        return;
+    double level = request_json["energy_level_mev"].asDouble();
+    if (level < 0 || level > 1000000) {
+      sendErrorResponse(res, 400,
+                        "Energy level must be between 0 and 1,000,000 MeV");
+      metrics_->incrementErrors();
+      return;
     }
+    field->energy_level_mev = level;
+    updated = true;
+  }
 
-    EnergyFieldResponse* field = it->second.get();
-    bool updated = false;
-
-    // Validate and update provided fields
-    if (request_json.isMember("energy_level_mev")) {
-        if (!request_json["energy_level_mev"].isNumeric()) {
-            sendErrorResponse(res, 400, "energy_level_mev must be numeric");
-            metrics_->incrementErrors();
-            return;
-        }
-        double level = request_json["energy_level_mev"].asDouble();
-        if (level < 0 || level > 1000000) {
-            sendErrorResponse(res, 400, "Energy level must be between 0 and 1,000,000 MeV");
-            metrics_->incrementErrors();
-            return;
-        }
-        field->energy_level_mev = level;
-        updated = true;
+  if (request_json.isMember("stability_factor")) {
+    if (!request_json["stability_factor"].isNumeric()) {
+      sendErrorResponse(res, 400, "stability_factor must be numeric");
+      metrics_->incrementErrors();
+      return;
     }
+    field->stability_factor = request_json["stability_factor"].asDouble();
+    updated = true;
+  }
 
-    if (request_json.isMember("stability_factor")) {
-        if (!request_json["stability_factor"].isNumeric()) {
-            sendErrorResponse(res, 400, "stability_factor must be numeric");
-            metrics_->incrementErrors();
-            return;
-        }
-        field->stability_factor = request_json["stability_factor"].asDouble();
-        updated = true;
+  if (request_json.isMember("dissipation_rate")) {
+    if (!request_json["dissipation_rate"].isNumeric()) {
+      sendErrorResponse(res, 400, "dissipation_rate must be numeric");
+      metrics_->incrementErrors();
+      return;
     }
+    field->dissipation_rate = request_json["dissipation_rate"].asDouble();
+    updated = true;
+  }
 
-    if (request_json.isMember("dissipation_rate")) {
-        if (!request_json["dissipation_rate"].isNumeric()) {
-            sendErrorResponse(res, 400, "dissipation_rate must be numeric");
-            metrics_->incrementErrors();
-            return;
-        }
-        field->dissipation_rate = request_json["dissipation_rate"].asDouble();
-        updated = true;
+  if (request_json.isMember("base_three_mev_per_sec")) {
+    if (!request_json["base_three_mev_per_sec"].isNumeric()) {
+      sendErrorResponse(res, 400, "base_three_mev_per_sec must be numeric");
+      metrics_->incrementErrors();
+      return;
     }
+    field->base_three_mev_per_sec =
+        request_json["base_three_mev_per_sec"].asDouble();
+    updated = true;
+  }
 
-    if (request_json.isMember("base_three_mev_per_sec")) {
-        if (!request_json["base_three_mev_per_sec"].isNumeric()) {
-            sendErrorResponse(res, 400, "base_three_mev_per_sec must be numeric");
-            metrics_->incrementErrors();
-            return;
-        }
-        field->base_three_mev_per_sec = request_json["base_three_mev_per_sec"].asDouble();
-        updated = true;
+  if (request_json.isMember("entropy_factor")) {
+    if (!request_json["entropy_factor"].isNumeric()) {
+      sendErrorResponse(res, 400, "entropy_factor must be numeric");
+      metrics_->incrementErrors();
+      return;
     }
+    field->entropy_factor = request_json["entropy_factor"].asDouble();
+    updated = true;
+  }
 
-    if (request_json.isMember("entropy_factor")) {
-        if (!request_json["entropy_factor"].isNumeric()) {
-            sendErrorResponse(res, 400, "entropy_factor must be numeric");
-            metrics_->incrementErrors();
-            return;
-        }
-        field->entropy_factor = request_json["entropy_factor"].asDouble();
-        updated = true;
+  if (request_json.isMember("status")) {
+    if (!request_json["status"].isString()) {
+      sendErrorResponse(res, 400, "status must be string");
+      metrics_->incrementErrors();
+      return;
     }
+    field->status = request_json["status"].asString();
+    updated = true;
+  }
 
-    if (request_json.isMember("status")) {
-        if (!request_json["status"].isString()) {
-            sendErrorResponse(res, 400, "status must be string");
-            metrics_->incrementErrors();
-            return;
-        }
-        field->status = request_json["status"].asString();
-        updated = true;
+  if (!updated) {
+    sendErrorResponse(res, 400, "No valid fields provided for update");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  field->last_updated = std::chrono::system_clock::now();
+
+  Json::Value response = field->toJson();
+  sendJSONResponse(res, 200, response);
+  metrics_->incrementSuccessful();
+
+  std::cout << "Energy field updated successfully: " << field_id << std::endl;
+}
+
+void HTTPTernaryFissionServer::handleEnergyFieldDelete(
+    const httplib::Request &req, httplib::Response &res) {
+  std::string field_id = req.matches[1];
+
+  std::lock_guard<std::mutex> lock(fields_mutex_);
+  auto it = energy_fields_.find(field_id);
+
+  if (it == energy_fields_.end()) {
+    sendErrorResponse(res, 404, "Energy field not found");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  energy_fields_.erase(it);
+
+  Json::Value response;
+  response["message"] = "Energy field deleted successfully";
+  response["field_id"] = field_id;
+
+  sendJSONResponse(res, 200, response);
+  metrics_->incrementSuccessful();
+}
+
+void HTTPTernaryFissionServer::handleSimulationStart(
+    const httplib::Request &req, httplib::Response &res) {
+  Json::Value request_json;
+  if (!req.body.empty() && !parseJSONRequest(req, request_json)) {
+    sendErrorResponse(res, 400, "Invalid JSON request body");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(simulation_mutex_);
+  if (!simulation_engine_) {
+    sendErrorResponse(res, 500, "Simulation engine not initialized");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  try {
+    Json::Value response =
+        simulation_engine_->startContinuousSimulationAPI(request_json);
+    if (response.isMember("status") &&
+        response["status"].asString() == "error") {
+      sendJSONResponse(res, 400, response);
+      metrics_->incrementErrors();
+    } else {
+      sendJSONResponse(res, 200, response);
+      metrics_->incrementSuccessful();
     }
+  } catch (const std::exception &e) {
+    sendErrorResponse(res, 500,
+                      std::string("Failed to start simulation: ") + e.what());
+    metrics_->incrementErrors();
+  }
+}
 
-    if (!updated) {
-        sendErrorResponse(res, 400, "No valid fields provided for update");
-        metrics_->incrementErrors();
-        return;
-    }
+void HTTPTernaryFissionServer::handleSimulationStop(
+    const httplib::Request & /*req*/, httplib::Response &res) {
+  std::lock_guard<std::mutex> lock(simulation_mutex_);
+  if (!simulation_engine_) {
+    sendErrorResponse(res, 500, "Simulation engine not initialized");
+    metrics_->incrementErrors();
+    return;
+  }
 
-    field->last_updated = std::chrono::system_clock::now();
-
-    Json::Value response = field->toJson();
+  try {
+    Json::Value response = simulation_engine_->stopContinuousSimulationAPI();
     sendJSONResponse(res, 200, response);
     metrics_->incrementSuccessful();
-
-    std::cout << "Energy field updated successfully: " << field_id << std::endl;
+  } catch (const std::exception &e) {
+    sendErrorResponse(res, 500,
+                      std::string("Failed to stop simulation: ") + e.what());
+    metrics_->incrementErrors();
+  }
 }
 
-void HTTPTernaryFissionServer::handleEnergyFieldDelete(const httplib::Request& req, httplib::Response& res) {
-    std::string field_id = req.matches[1];
-    
-    std::lock_guard<std::mutex> lock(fields_mutex_);
-    auto it = energy_fields_.find(field_id);
-    
-    if (it == energy_fields_.end()) {
-        sendErrorResponse(res, 404, "Energy field not found");
-        metrics_->incrementErrors();
-        return;
-    }
-    
-    energy_fields_.erase(it);
-    
+void HTTPTernaryFissionServer::handleSimulationReset(
+    const httplib::Request & /*req*/, httplib::Response &res) {
+  std::lock_guard<std::mutex> lock(simulation_mutex_);
+  if (!simulation_engine_) {
+    sendErrorResponse(res, 500, "Simulation engine not initialized");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  try {
+    simulation_engine_->shutdown();
+    simulation_engine_ = std::make_shared<TernaryFissionSimulationEngine>();
+
     Json::Value response;
-    response["message"] = "Energy field deleted successfully";
-    response["field_id"] = field_id;
-    
+    response["status"] = "success";
+    response["message"] = "Simulation reset successfully";
+    response["simulation_running"] = false;
+
     sendJSONResponse(res, 200, response);
     metrics_->incrementSuccessful();
-}
-
-void HTTPTernaryFissionServer::handleSimulationStart(const httplib::Request& req, httplib::Response& res) {
-    Json::Value request_json;
-    if (!req.body.empty() && !parseJSONRequest(req, request_json)) {
-        sendErrorResponse(res, 400, "Invalid JSON request body");
-        metrics_->incrementErrors();
-        return;
-    }
-
-    std::lock_guard<std::mutex> lock(simulation_mutex_);
-    if (!simulation_engine_) {
-        sendErrorResponse(res, 500, "Simulation engine not initialized");
-        metrics_->incrementErrors();
-        return;
-    }
-
-    try {
-        Json::Value response = simulation_engine_->startContinuousSimulationAPI(request_json);
-        if (response.isMember("status") && response["status"].asString() == "error") {
-            sendJSONResponse(res, 400, response);
-            metrics_->incrementErrors();
-        } else {
-            sendJSONResponse(res, 200, response);
-            metrics_->incrementSuccessful();
-        }
-    } catch (const std::exception& e) {
-        sendErrorResponse(res, 500, std::string("Failed to start simulation: ") + e.what());
-        metrics_->incrementErrors();
-    }
-}
-
-void HTTPTernaryFissionServer::handleSimulationStop(const httplib::Request& /*req*/, httplib::Response& res) {
-    std::lock_guard<std::mutex> lock(simulation_mutex_);
-    if (!simulation_engine_) {
-        sendErrorResponse(res, 500, "Simulation engine not initialized");
-        metrics_->incrementErrors();
-        return;
-    }
-
-    try {
-        Json::Value response = simulation_engine_->stopContinuousSimulationAPI();
-        sendJSONResponse(res, 200, response);
-        metrics_->incrementSuccessful();
-    } catch (const std::exception& e) {
-        sendErrorResponse(res, 500, std::string("Failed to stop simulation: ") + e.what());
-        metrics_->incrementErrors();
-    }
-}
-
-void HTTPTernaryFissionServer::handleSimulationReset(const httplib::Request& /*req*/, httplib::Response& res) {
-    std::lock_guard<std::mutex> lock(simulation_mutex_);
-    if (!simulation_engine_) {
-        sendErrorResponse(res, 500, "Simulation engine not initialized");
-        metrics_->incrementErrors();
-        return;
-    }
-
-    try {
-        simulation_engine_->shutdown();
-        simulation_engine_ = std::make_shared<TernaryFissionSimulationEngine>();
-
-        Json::Value response;
-        response["status"] = "success";
-        response["message"] = "Simulation reset successfully";
-        response["simulation_running"] = false;
-
-        sendJSONResponse(res, 200, response);
-        metrics_->incrementSuccessful();
-    } catch (const std::exception& e) {
-        sendErrorResponse(res, 500, std::string("Failed to reset simulation: ") + e.what());
-        metrics_->incrementErrors();
-    }
+  } catch (const std::exception &e) {
+    sendErrorResponse(res, 500,
+                      std::string("Failed to reset simulation: ") + e.what());
+    metrics_->incrementErrors();
+  }
 }
 
 /**
  * We handle portal trigger endpoint requests
  * This method schedules a timed energy load through the simulation engine
  */
-void HTTPTernaryFissionServer::handlePortalTrigger(const httplib::Request& req, httplib::Response& res) {
-    Json::Value body;
-    if (!parseJSONRequest(req, body)) {
-        sendErrorResponse(res, 400, "Invalid JSON request body");
-        metrics_->incrementErrors();
-        return;
-    }
+void HTTPTernaryFissionServer::handlePortalTrigger(const httplib::Request &req,
+                                                   httplib::Response &res) {
+  Json::Value body;
+  if (!parseJSONRequest(req, body)) {
+    sendErrorResponse(res, 400, "Invalid JSON request body");
+    metrics_->incrementErrors();
+    return;
+  }
 
-    double duration = body.get("duration_seconds", 900.0).asDouble();
-    if (duration <= 0.0) {
-        duration = 900.0;
-    }
-    double power = body.get("power_level_mev", 0.0).asDouble();
-    double extra = body.get("additional_power_mev", 0.0).asDouble();
+  double duration = body.get("duration_seconds", 900.0).asDouble();
+  if (duration <= 0.0) {
+    duration = 900.0;
+  }
+  double power = body.get("power_level_mev", 0.0).asDouble();
+  double extra = body.get("additional_power_mev", 0.0).asDouble();
 
-    double estimated = calculateEstimatedPower(power, static_cast<int>(duration), extra);
-    double extension = 1.0;
-    if (power > 0.0 && extra > 0.0) {
-        extension += extra / power;
-    }
-    double adjusted_duration = duration * extension;
-    double total_power = power + extra;
+  double estimated =
+      calculateEstimatedPower(power, static_cast<int>(duration), extra);
+  double extension = 1.0;
+  if (power > 0.0 && extra > 0.0) {
+    extension += extra / power;
+  }
+  double adjusted_duration = duration * extension;
+  double total_power = power + extra;
 
-    {
-        std::lock_guard<std::mutex> lock(simulation_mutex_);
-        if (!simulation_engine_) {
-            sendErrorResponse(res, 500, "Simulation engine not initialized");
-            metrics_->incrementErrors();
-            return;
-        }
-        simulation_engine_->startPortalLoad(adjusted_duration, total_power);
-        auto start = std::chrono::system_clock::now();
-        auto end = start + std::chrono::seconds(static_cast<int>(adjusted_duration));
-        simulation_engine_->setPortalEventState(start, end, estimated);
-    }
-
-    Json::Value ack;
-    ack["scheduled_duration_seconds"] = adjusted_duration;
-    ack["projected_power_level_mev"] = total_power;
-
-    sendJSONResponse(res, 200, ack);
-    metrics_->incrementSuccessful();
-}
-
-void HTTPTernaryFissionServer::handleStreamStart(const httplib::Request& /*req*/, httplib::Response& res) {
-    if (!media_streaming_manager_) {
-        sendErrorResponse(res, 400, "Media streaming not enabled");
-        metrics_->incrementErrors();
-        return;
-    }
-
-    if (media_streaming_manager_->startStreaming()) {
-        Json::Value response;
-        response["status"] = "started";
-        sendJSONResponse(res, 200, response);
-        metrics_->incrementSuccessful();
-    } else {
-        sendErrorResponse(res, 500, "Failed to start media streaming");
-        metrics_->incrementErrors();
-    }
-}
-
-void HTTPTernaryFissionServer::handleStreamStop(const httplib::Request& /*req*/, httplib::Response& res) {
-    if (!media_streaming_manager_) {
-        sendErrorResponse(res, 400, "Media streaming not enabled");
-        metrics_->incrementErrors();
-        return;
-    }
-
-    if (media_streaming_manager_->stopStreaming()) {
-        Json::Value response;
-        response["status"] = "stopped";
-        sendJSONResponse(res, 200, response);
-        metrics_->incrementSuccessful();
-    } else {
-        sendErrorResponse(res, 500, "Failed to stop media streaming");
-        metrics_->incrementErrors();
-    }
-}
-
-void HTTPTernaryFissionServer::handleFissionCalculation(const httplib::Request& req, httplib::Response& res) {
-    Json::Value body;
-    if (!parseJSONRequest(req, body)) {
-        sendErrorResponse(res, 400, "Invalid JSON payload");
-        metrics_->incrementErrors();
-        return;
-    }
-
+  {
+    std::lock_guard<std::mutex> lock(simulation_mutex_);
     if (!simulation_engine_) {
-        sendErrorResponse(res, 500, "Simulation engine unavailable");
-        metrics_->incrementErrors();
-        return;
+      sendErrorResponse(res, 500, "Simulation engine not initialized");
+      metrics_->incrementErrors();
+      return;
     }
+    simulation_engine_->startPortalLoad(adjusted_duration, total_power);
+    auto start = std::chrono::system_clock::now();
+    auto end =
+        start + std::chrono::seconds(static_cast<int>(adjusted_duration));
+    simulation_engine_->setPortalEventState(start, end, estimated);
+  }
 
-    double parent_mass = body.get("parent_mass", 0.0).asDouble();
-    double excitation_energy = body.get("excitation_energy", 0.0).asDouble();
+  Json::Value ack;
+  ack["scheduled_duration_seconds"] = adjusted_duration;
+  ack["projected_power_level_mev"] = total_power;
 
-    if (parent_mass <= 0.0 || parent_mass > 300.0) {
-        sendErrorResponse(res, 400, "parent_mass must be between 0 and 300 AMU");
-        metrics_->incrementErrors();
-        return;
-    }
-
-    if (excitation_energy < 0.0 || excitation_energy > 100.0) {
-        sendErrorResponse(res, 400, "excitation_energy must be between 0 and 100 MeV");
-        metrics_->incrementErrors();
-        return;
-    }
-
-    try {
-        TernaryFissionEvent event = simulation_engine_->simulateTernaryFissionEvent(parent_mass, excitation_energy);
-
-        Json::Value response;
-        response["q_value"] = event.q_value;
-        response["total_kinetic_energy"] = event.total_kinetic_energy;
-
-        auto serializeFragment = [](const FissionFragment& frag) {
-            Json::Value jf;
-            jf["mass"] = frag.mass;
-            jf["atomic_number"] = static_cast<Json::Int64>(frag.atomic_number);
-            jf["mass_number"] = static_cast<Json::Int64>(frag.mass_number);
-            jf["kinetic_energy"] = frag.kinetic_energy;
-            jf["binding_energy"] = frag.binding_energy;
-            jf["excitation_energy"] = frag.excitation_energy;
-            jf["half_life"] = frag.half_life;
-            Json::Value momentum;
-            momentum["x"] = frag.momentum.x;
-            momentum["y"] = frag.momentum.y;
-            momentum["z"] = frag.momentum.z;
-            jf["momentum"] = momentum;
-            Json::Value position;
-            position["x"] = frag.position.x;
-            position["y"] = frag.position.y;
-            position["z"] = frag.position.z;
-            jf["position"] = position;
-            return jf;
-        };
-
-        response["heavy_fragment"] = serializeFragment(event.heavy_fragment);
-        response["light_fragment"] = serializeFragment(event.light_fragment);
-        response["alpha_particle"] = serializeFragment(event.alpha_particle);
-
-        sendJSONResponse(res, 200, response);
-    } catch (const std::exception& e) {
-        sendErrorResponse(res, 500, std::string("Fission calculation failed: ") + e.what());
-        metrics_->incrementErrors();
-    }
+  sendJSONResponse(res, 200, ack);
+  metrics_->incrementSuccessful();
 }
 
-void HTTPTernaryFissionServer::handleConservationLaws(const httplib::Request& req, httplib::Response& res) {
-    Json::Value body;
-    if (!parseJSONRequest(req, body)) {
-        sendErrorResponse(res, 400, "Invalid JSON payload");
-        metrics_->incrementErrors();
-        return;
-    }
+void HTTPTernaryFissionServer::handleStreamStart(
+    const httplib::Request & /*req*/, httplib::Response &res) {
+  if (!media_streaming_manager_) {
+    sendErrorResponse(res, 400, "Media streaming not enabled");
+    metrics_->incrementErrors();
+    return;
+  }
 
-    try {
-        TernaryFissionEvent event;
-        event.event_id = body.get("event_id", 0).asUInt64();
-        event.energy_field_id = body.get("energy_field_id", 0).asUInt64();
-        event.q_value = body.get("q_value", 0.0).asDouble();
-
-        auto parseFragment = [](const Json::Value& jf, FissionFragment& frag) {
-            frag.mass = jf.get("mass", 0.0).asDouble();
-            frag.atomic_number = jf.get("atomic_number", 0).asInt();
-            frag.mass_number = jf.get("mass_number", 0).asInt();
-            frag.kinetic_energy = jf.get("kinetic_energy", 0.0).asDouble();
-            frag.binding_energy = jf.get("binding_energy", 0.0).asDouble();
-            frag.excitation_energy = jf.get("excitation_energy", 0.0).asDouble();
-            frag.half_life = jf.get("half_life", 0.0).asDouble();
-            const Json::Value& momentum = jf["momentum"];
-            frag.momentum.x = momentum.get("x", 0.0).asDouble();
-            frag.momentum.y = momentum.get("y", 0.0).asDouble();
-            frag.momentum.z = momentum.get("z", 0.0).asDouble();
-            const Json::Value& position = jf["position"];
-            frag.position.x = position.get("x", 0.0).asDouble();
-            frag.position.y = position.get("y", 0.0).asDouble();
-            frag.position.z = position.get("z", 0.0).asDouble();
-        };
-
-        parseFragment(body["heavy_fragment"], event.heavy_fragment);
-        parseFragment(body["light_fragment"], event.light_fragment);
-        parseFragment(body["alpha_particle"], event.alpha_particle);
-
-        event.total_kinetic_energy = event.heavy_fragment.kinetic_energy +
-                                    event.light_fragment.kinetic_energy +
-                                    event.alpha_particle.kinetic_energy;
-        event.binding_energy_released = event.q_value - event.total_kinetic_energy;
-
-        // Calculate conservation errors
-        double total_px = event.heavy_fragment.momentum.x + event.light_fragment.momentum.x +
-                          event.alpha_particle.momentum.x;
-        double total_py = event.heavy_fragment.momentum.y + event.light_fragment.momentum.y +
-                          event.alpha_particle.momentum.y;
-        double total_pz = event.heavy_fragment.momentum.z + event.light_fragment.momentum.z +
-                          event.alpha_particle.momentum.z;
-
-        event.momentum_conservation_error =
-            std::sqrt(total_px * total_px + total_py * total_py + total_pz * total_pz);
-        event.momentum_conserved = event.momentum_conservation_error < 1e-6;
-
-        event.energy_conservation_error =
-            std::abs(event.q_value - event.total_kinetic_energy);
-        event.energy_conserved = event.energy_conservation_error < 1e-3;
-
-        bool ok = event.energy_conserved && event.momentum_conserved;
-
-        Json::Value response;
-        response["conserved"] = ok;
-        response["energy_conservation_error"] = event.energy_conservation_error;
-        response["momentum_conservation_error"] = event.momentum_conservation_error;
-        sendJSONResponse(res, 200, response);
-    } catch (const std::exception& e) {
-        sendErrorResponse(res, 400, std::string("Invalid event data: ") + e.what());
-        metrics_->incrementErrors();
-    }
-}
-
-void HTTPTernaryFissionServer::handleEnergyGeneration(const httplib::Request& req, httplib::Response& res) {
-    Json::Value body;
-    if (!parseJSONRequest(req, body)) {
-        sendErrorResponse(res, 400, "Invalid JSON payload");
-        metrics_->incrementErrors();
-        return;
-    }
-
-    if (!simulation_engine_) {
-        sendErrorResponse(res, 500, "Simulation engine unavailable");
-        metrics_->incrementErrors();
-        return;
-    }
-
-    double energy_mev = body.get("energy_mev", 0.0).asDouble();
-    int rounds = body.get("dissipation_rounds", 0).asInt();
-
-    if (energy_mev <= 0.0) {
-        sendErrorResponse(res, 400, "energy_mev must be positive");
-        metrics_->incrementErrors();
-        return;
-    }
-
-    try {
-        EnergyField field = simulation_engine_->createEnergyField(energy_mev);
-        if (rounds > 0) {
-            simulation_engine_->dissipateEnergyField(field, rounds);
-        }
-
-        Json::Value jf;
-        jf["field_id"] = static_cast<Json::UInt64>(field.field_id);
-        jf["energy_mev"] = field.energy_mev;
-        jf["memory_bytes"] = static_cast<Json::UInt64>(field.memory_bytes);
-        jf["cpu_cycles"] = static_cast<Json::UInt64>(field.cpu_cycles);
-        jf["entropy_factor"] = field.entropy_factor;
-        jf["dissipation_rate"] = field.dissipation_rate;
-        jf["stability_factor"] = field.stability_factor;
-        jf["interaction_strength"] = field.interaction_strength;
-
-        auto time_since_epoch = field.creation_time.time_since_epoch();
-        auto timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(time_since_epoch).count();
-        jf["creation_time_ms"] = static_cast<Json::Int64>(timestamp_ms);
-
-        sendJSONResponse(res, 200, jf);
-    } catch (const std::exception& e) {
-        sendErrorResponse(res, 500, std::string("Energy generation failed: ") + e.what());
-        metrics_->incrementErrors();
-    }
-}
-
-void HTTPTernaryFissionServer::handleFieldStatistics(const httplib::Request& /*req*/, httplib::Response& res) {
-    Json::Value stats = computeFieldStatistics();
-    sendJSONResponse(res, 200, stats);
+  if (media_streaming_manager_->startStreaming()) {
+    Json::Value response;
+    response["status"] = "started";
+    sendJSONResponse(res, 200, response);
     metrics_->incrementSuccessful();
+  } else {
+    sendErrorResponse(res, 500, "Failed to start media streaming");
+    metrics_->incrementErrors();
+  }
+}
+
+void HTTPTernaryFissionServer::handleStreamStop(
+    const httplib::Request & /*req*/, httplib::Response &res) {
+  if (!media_streaming_manager_) {
+    sendErrorResponse(res, 400, "Media streaming not enabled");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  if (media_streaming_manager_->stopStreaming()) {
+    Json::Value response;
+    response["status"] = "stopped";
+    sendJSONResponse(res, 200, response);
+    metrics_->incrementSuccessful();
+  } else {
+    sendErrorResponse(res, 500, "Failed to stop media streaming");
+    metrics_->incrementErrors();
+  }
+}
+
+void HTTPTernaryFissionServer::handleFissionCalculation(
+    const httplib::Request &req, httplib::Response &res) {
+  Json::Value body;
+  if (!parseJSONRequest(req, body)) {
+    sendErrorResponse(res, 400, "Invalid JSON payload");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  if (!simulation_engine_) {
+    sendErrorResponse(res, 500, "Simulation engine unavailable");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  double parent_mass = body.get("parent_mass", 0.0).asDouble();
+  double excitation_energy = body.get("excitation_energy", 0.0).asDouble();
+
+  if (parent_mass <= 0.0 || parent_mass > 300.0) {
+    sendErrorResponse(res, 400, "parent_mass must be between 0 and 300 AMU");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  if (excitation_energy < 0.0 || excitation_energy > 100.0) {
+    sendErrorResponse(res, 400,
+                      "excitation_energy must be between 0 and 100 MeV");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  try {
+    TernaryFissionEvent event = simulation_engine_->simulateTernaryFissionEvent(
+        parent_mass, excitation_energy);
+
+    Json::Value response;
+    response["q_value"] = event.q_value;
+    response["total_kinetic_energy"] = event.total_kinetic_energy;
+
+    auto serializeFragment = [](const FissionFragment &frag) {
+      Json::Value jf;
+      jf["mass"] = frag.mass;
+      jf["atomic_number"] = static_cast<Json::Int64>(frag.atomic_number);
+      jf["mass_number"] = static_cast<Json::Int64>(frag.mass_number);
+      jf["kinetic_energy"] = frag.kinetic_energy;
+      jf["binding_energy"] = frag.binding_energy;
+      jf["excitation_energy"] = frag.excitation_energy;
+      jf["half_life"] = frag.half_life;
+      Json::Value momentum;
+      momentum["x"] = frag.momentum.x;
+      momentum["y"] = frag.momentum.y;
+      momentum["z"] = frag.momentum.z;
+      jf["momentum"] = momentum;
+      Json::Value position;
+      position["x"] = frag.position.x;
+      position["y"] = frag.position.y;
+      position["z"] = frag.position.z;
+      jf["position"] = position;
+      return jf;
+    };
+
+    response["heavy_fragment"] = serializeFragment(event.heavy_fragment);
+    response["light_fragment"] = serializeFragment(event.light_fragment);
+    response["alpha_particle"] = serializeFragment(event.alpha_particle);
+
+    sendJSONResponse(res, 200, response);
+  } catch (const std::exception &e) {
+    sendErrorResponse(res, 500,
+                      std::string("Fission calculation failed: ") + e.what());
+    metrics_->incrementErrors();
+  }
+}
+
+void HTTPTernaryFissionServer::handleConservationLaws(
+    const httplib::Request &req, httplib::Response &res) {
+  Json::Value body;
+  if (!parseJSONRequest(req, body)) {
+    sendErrorResponse(res, 400, "Invalid JSON payload");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  try {
+    TernaryFissionEvent event;
+    event.event_id = body.get("event_id", 0).asUInt64();
+    event.energy_field_id = body.get("energy_field_id", 0).asUInt64();
+    event.q_value = body.get("q_value", 0.0).asDouble();
+
+    auto parseFragment = [](const Json::Value &jf, FissionFragment &frag) {
+      frag.mass = jf.get("mass", 0.0).asDouble();
+      frag.atomic_number = jf.get("atomic_number", 0).asInt();
+      frag.mass_number = jf.get("mass_number", 0).asInt();
+      frag.kinetic_energy = jf.get("kinetic_energy", 0.0).asDouble();
+      frag.binding_energy = jf.get("binding_energy", 0.0).asDouble();
+      frag.excitation_energy = jf.get("excitation_energy", 0.0).asDouble();
+      frag.half_life = jf.get("half_life", 0.0).asDouble();
+      const Json::Value &momentum = jf["momentum"];
+      frag.momentum.x = momentum.get("x", 0.0).asDouble();
+      frag.momentum.y = momentum.get("y", 0.0).asDouble();
+      frag.momentum.z = momentum.get("z", 0.0).asDouble();
+      const Json::Value &position = jf["position"];
+      frag.position.x = position.get("x", 0.0).asDouble();
+      frag.position.y = position.get("y", 0.0).asDouble();
+      frag.position.z = position.get("z", 0.0).asDouble();
+    };
+
+    parseFragment(body["heavy_fragment"], event.heavy_fragment);
+    parseFragment(body["light_fragment"], event.light_fragment);
+    parseFragment(body["alpha_particle"], event.alpha_particle);
+
+    event.total_kinetic_energy = event.heavy_fragment.kinetic_energy +
+                                 event.light_fragment.kinetic_energy +
+                                 event.alpha_particle.kinetic_energy;
+    event.binding_energy_released = event.q_value - event.total_kinetic_energy;
+
+    // Calculate conservation errors
+    double total_px = event.heavy_fragment.momentum.x +
+                      event.light_fragment.momentum.x +
+                      event.alpha_particle.momentum.x;
+    double total_py = event.heavy_fragment.momentum.y +
+                      event.light_fragment.momentum.y +
+                      event.alpha_particle.momentum.y;
+    double total_pz = event.heavy_fragment.momentum.z +
+                      event.light_fragment.momentum.z +
+                      event.alpha_particle.momentum.z;
+
+    event.momentum_conservation_error = std::sqrt(
+        total_px * total_px + total_py * total_py + total_pz * total_pz);
+    event.momentum_conserved = event.momentum_conservation_error < 1e-6;
+
+    event.energy_conservation_error =
+        std::abs(event.q_value - event.total_kinetic_energy);
+    event.energy_conserved = event.energy_conservation_error < 1e-3;
+
+    bool ok = event.energy_conserved && event.momentum_conserved;
+
+    Json::Value response;
+    response["conserved"] = ok;
+    response["energy_conservation_error"] = event.energy_conservation_error;
+    response["momentum_conservation_error"] = event.momentum_conservation_error;
+    sendJSONResponse(res, 200, response);
+  } catch (const std::exception &e) {
+    sendErrorResponse(res, 400, std::string("Invalid event data: ") + e.what());
+    metrics_->incrementErrors();
+  }
+}
+
+void HTTPTernaryFissionServer::handleEnergyGeneration(
+    const httplib::Request &req, httplib::Response &res) {
+  Json::Value body;
+  if (!parseJSONRequest(req, body)) {
+    sendErrorResponse(res, 400, "Invalid JSON payload");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  if (!simulation_engine_) {
+    sendErrorResponse(res, 500, "Simulation engine unavailable");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  double energy_mev = body.get("energy_mev", 0.0).asDouble();
+  int rounds = body.get("dissipation_rounds", 0).asInt();
+
+  if (energy_mev <= 0.0) {
+    sendErrorResponse(res, 400, "energy_mev must be positive");
+    metrics_->incrementErrors();
+    return;
+  }
+
+  try {
+    EnergyField field = simulation_engine_->createEnergyField(energy_mev);
+    if (rounds > 0) {
+      simulation_engine_->dissipateEnergyField(field, rounds);
+    }
+
+    Json::Value jf;
+    jf["field_id"] = static_cast<Json::UInt64>(field.field_id);
+    jf["energy_mev"] = field.energy_mev;
+    jf["memory_bytes"] = static_cast<Json::UInt64>(field.memory_bytes);
+    jf["cpu_cycles"] = static_cast<Json::UInt64>(field.cpu_cycles);
+    jf["entropy_factor"] = field.entropy_factor;
+    jf["dissipation_rate"] = field.dissipation_rate;
+    jf["stability_factor"] = field.stability_factor;
+    jf["interaction_strength"] = field.interaction_strength;
+
+    auto time_since_epoch = field.creation_time.time_since_epoch();
+    auto timestamp_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(time_since_epoch)
+            .count();
+    jf["creation_time_ms"] = static_cast<Json::Int64>(timestamp_ms);
+
+    sendJSONResponse(res, 200, jf);
+  } catch (const std::exception &e) {
+    sendErrorResponse(res, 500,
+                      std::string("Energy generation failed: ") + e.what());
+    metrics_->incrementErrors();
+  }
+}
+
+void HTTPTernaryFissionServer::handleFieldStatistics(
+    const httplib::Request & /*req*/, httplib::Response &res) {
+  Json::Value stats = computeFieldStatistics();
+  sendJSONResponse(res, 200, stats);
+  metrics_->incrementSuccessful();
 }
 
 Json::Value HTTPTernaryFissionServer::computeFieldStatistics() const {
-    Json::Value stats;
-    std::lock_guard<std::mutex> lock(fields_mutex_);
+  Json::Value stats;
+  std::lock_guard<std::mutex> lock(fields_mutex_);
 
-    int total_fields = static_cast<int>(energy_fields_.size());
-    int active_fields = 0;
-    double total_energy = 0.0;
-    double peak_energy = 0.0;
+  int total_fields = static_cast<int>(energy_fields_.size());
+  int active_fields = 0;
+  double total_energy = 0.0;
+  double peak_energy = 0.0;
 
-    for (const auto& [field_id, field] : energy_fields_) {
-        total_energy += field->energy_level_mev;
-        if (field->energy_level_mev > peak_energy) {
-            peak_energy = field->energy_level_mev;
-        }
-        if (field->status == "active" || field->active) {
-            active_fields++;
-        }
+  for (const auto &[field_id, field] : energy_fields_) {
+    total_energy += field->energy_level_mev;
+    if (field->energy_level_mev > peak_energy) {
+      peak_energy = field->energy_level_mev;
     }
+    if (field->status == "active" || field->active) {
+      active_fields++;
+    }
+  }
 
-    int inactive_fields = total_fields - active_fields;
-    double average_energy = total_fields > 0 ? total_energy / total_fields : 0.0;
+  int inactive_fields = total_fields - active_fields;
+  double average_energy = total_fields > 0 ? total_energy / total_fields : 0.0;
 
-    stats["total_fields"] = static_cast<Json::Int64>(total_fields);
-    stats["active_fields"] = static_cast<Json::Int64>(active_fields);
-    stats["inactive_fields"] = static_cast<Json::Int64>(inactive_fields);
-    stats["total_energy_mev"] = total_energy;
-    stats["average_energy_mev"] = average_energy;
-    stats["peak_energy_mev"] = peak_energy;
+  stats["total_fields"] = static_cast<Json::Int64>(total_fields);
+  stats["active_fields"] = static_cast<Json::Int64>(active_fields);
+  stats["inactive_fields"] = static_cast<Json::Int64>(inactive_fields);
+  stats["total_energy_mev"] = total_energy;
+  stats["average_energy_mev"] = average_energy;
+  stats["peak_energy_mev"] = peak_energy;
 
-    return stats;
+  return stats;
 }
 
-void HTTPTernaryFissionServer::addEnergyField(const EnergyFieldResponse& field) {
-    std::lock_guard<std::mutex> lock(fields_mutex_);
-    auto new_field = std::make_unique<EnergyFieldResponse>(field);
-    energy_fields_[new_field->field_id] = std::move(new_field);
+void HTTPTernaryFissionServer::addEnergyField(
+    const EnergyFieldResponse &field) {
+  std::lock_guard<std::mutex> lock(fields_mutex_);
+  auto new_field = std::make_unique<EnergyFieldResponse>(field);
+  energy_fields_[new_field->field_id] = std::move(new_field);
 }
 
 // We implement remaining interface methods
 bool HTTPTernaryFissionServer::reloadConfiguration() {
-    return config_manager_->reloadConfiguration();
+  return config_manager_->reloadConfiguration();
 }
 
 bool HTTPTernaryFissionServer::validateConfiguration() const {
-    return config_manager_->validateConfiguration();
+  return config_manager_->validateConfiguration();
 }
 
-std::vector<EnergyFieldResponse> HTTPTernaryFissionServer::getActiveEnergyFields() const {
-    std::vector<EnergyFieldResponse> fields;
-    std::lock_guard<std::mutex> lock(fields_mutex_);
+std::vector<EnergyFieldResponse>
+HTTPTernaryFissionServer::getActiveEnergyFields() const {
+  std::vector<EnergyFieldResponse> fields;
+  std::lock_guard<std::mutex> lock(fields_mutex_);
 
-    for (const auto& [field_id, field] : energy_fields_) {
-        if (field->status == "active" || field->active) {
-            fields.push_back(*field);
-        }
+  for (const auto &[field_id, field] : energy_fields_) {
+    if (field->status == "active" || field->active) {
+      fields.push_back(*field);
     }
+  }
 
-    return fields;
+  return fields;
 }
 
 size_t HTTPTernaryFissionServer::getActiveWebSocketConnections() const {
-    std::lock_guard<std::mutex> lock(websocket_mutex_);
-    return websocket_connections_.size();
+  std::lock_guard<std::mutex> lock(websocket_mutex_);
+  return websocket_connections_.size();
 }
 
 std::string HTTPTernaryFissionServer::generateConnectionID() {
-    static std::atomic<int64_t> counter{1};
-    int64_t id = counter.fetch_add(1, std::memory_order_relaxed);
-    return "ws_" + std::to_string(id);
+  static std::atomic<int64_t> counter{1};
+  int64_t id = counter.fetch_add(1, std::memory_order_relaxed);
+  return "ws_" + std::to_string(id);
 }
 
-Json::Value HTTPTernaryFissionServer::processPhysicsRequest(const Json::Value& /*request*/) {
-    // Physics request processing will be implemented with engine integration
-    Json::Value response;
-    response["status"] = "not_implemented";
-    response["message"] = "Physics engine integration pending";
-    return response;
+Json::Value HTTPTernaryFissionServer::processPhysicsRequest(
+    const Json::Value & /*request*/) {
+  // Physics request processing will be implemented with engine integration
+  Json::Value response;
+  response["status"] = "not_implemented";
+  response["message"] = "Physics engine integration pending";
+  return response;
 }
 
 } // namespace TernaryFission


### PR DESCRIPTION
## Summary
- add `ssl_cert_chain` and `ssl_private_key` fields to configuration
- parse new TLS paths without requiring CA files
- load TLS certificate chain in C++ and Go servers
- update sample configs with default certificate locations

## Testing
- `make cpp-build`
- `make cpp-test` *(fails: No rule to make target 'cpp-test')*
- `make static-analysis` *(fails: No rule to make target 'static-analysis')*
- `make go-build`
- `go test ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `go test ./src/go/...`

------
https://chatgpt.com/codex/tasks/task_e_68996592c5fc832b9f80cdf1c8c80a52